### PR TITLE
Localization/rendering support

### DIFF
--- a/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/ConnectionAccess.java
+++ b/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/ConnectionAccess.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.accessor;
+
+import io.netty.channel.Channel;
+import net.minecraft.network.Connection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Connection.class)
+public interface ConnectionAccess {
+  @Accessor
+  Channel getChannel();
+}

--- a/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/ServerboundClientInformationPacketAccess.java
+++ b/src/accessor/java/net/kyori/adventure/platform/fabric/impl/accessor/ServerboundClientInformationPacketAccess.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.accessor;
+
+import net.minecraft.network.protocol.game.ServerboundClientInformationPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerboundClientInformationPacket.class)
+public interface ServerboundClientInformationPacketAccess {
+  @Accessor
+  String getLanguage();
+}

--- a/src/accessor/resources/adventure-platform-fabric.accessor.mixins.json
+++ b/src/accessor/resources/adventure-platform-fabric.accessor.mixins.json
@@ -6,6 +6,8 @@
   "mixins": [
     "ClientboundBossEventPacketAccess",
     "ComponentSerializerAccess",
+    "ConnectionAccess",
+    "ServerboundClientInformationPacketAccess",
     "SoundSourceAccess"
   ],
   "injectors": {

--- a/src/main/java/net/kyori/adventure/platform/fabric/AdventureCommandSourceStack.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/AdventureCommandSourceStack.java
@@ -29,19 +29,24 @@ import net.kyori.adventure.text.Component;
 
 /**
  * An interface applied to {@link net.minecraft.commands.CommandSourceStack} to allow sending {@link Component Components}
+ *
+ * @since 4.0.0
  */
 public interface AdventureCommandSourceStack extends ForwardingAudience.Single {
   /**
-   * Send a result message to the command source
+   * Send a result message to the command source.
    *
    * @param text The text to send
    * @param sendToOps If this message should be sent to all ops listening
+   * @since 4.0.0
    */
   void sendSuccess(Component text, boolean sendToOps);
 
   /**
-   * Send an error message to the command source
+   * Send an error message to the command source.
+   *
    * @param text The error
+   * @since 4.0.0
    */
   void sendFailure(Component text);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/ComponentArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/ComponentArgumentType.java
@@ -43,6 +43,7 @@ import net.minecraft.commands.arguments.ComponentArgument;
  *
  * <p>At the moment, using this argument type will require this mod
  * <strong>both server- and clientside</strong>.
+ * @since 4.0.0
  */
 public final class ComponentArgumentType implements ArgumentType<Component> {
 
@@ -56,6 +57,7 @@ public final class ComponentArgumentType implements ArgumentType<Component> {
    * Get the argument type for component arguments
    *
    * @return argument type instance
+   * @since 4.0.0
    */
   public static ComponentArgumentType component() {
     return INSTANCE;
@@ -67,6 +69,7 @@ public final class ComponentArgumentType implements ArgumentType<Component> {
    * @param ctx Context to get from
    * @param key argument key
    * @return parsed component
+   * @since 4.0.0
    */
   public static Component component(final CommandContext<?> ctx, final String key) {
     return ctx.getArgument(key, Component.class);

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
@@ -44,12 +44,14 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>See {@link FabricServerAudienceProvider} for logical server-specific operations,
  * and {@link FabricClientAudienceProvider} for logical client-specific operations</p>
+ * @since 4.0.0
  */
 public interface FabricAudiences {
   /**
    * Return a {@link PlainComponentSerializer} instance that can resolve key bindings and translations using the game's data
    *
    * @return the plain serializer instance
+   * @since 4.0.0
    */
   PlainComponentSerializer plainSerializer();
 
@@ -59,6 +61,7 @@ public interface FabricAudiences {
    * @param input source component
    * @param modifier operator to transform the component
    * @return new component
+   * @since 4.0.0
    */
   static net.minecraft.network.chat.Component update(net.minecraft.network.chat.Component input, UnaryOperator<Component> modifier) {
     final Component modified;
@@ -79,6 +82,7 @@ public interface FabricAudiences {
    *
    * @param loc The Identifier to convert
    * @return The equivalent data as a Key
+   * @since 4.0.0
    */
   static @PolyNull Key toAdventure(@PolyNull ResourceLocation loc) {
     if(loc == null) {
@@ -92,6 +96,7 @@ public interface FabricAudiences {
    *
    * @param key The Key to convert
    * @return The equivalent data as an Identifier
+   * @since 4.0.0
    */
   static @PolyNull ResourceLocation toNative(@PolyNull Key key) {
     if(key == null) {
@@ -108,6 +113,7 @@ public interface FabricAudiences {
    * instances suitable for passing around the game.
    *
    * @return a serializer instance
+   * @since 4.0.0
    */
   static ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> nonWrappingSerializer() {
     return NonWrappingComponentSerializer.INSTANCE;
@@ -117,6 +123,7 @@ public interface FabricAudiences {
    * Active locale-based renderer for operations on provided audiences.
    *
    * @return Shared renderer
+   * @since 4.0.0
    */
   ComponentRenderer<Locale> localeRenderer();
 
@@ -127,6 +134,7 @@ public interface FabricAudiences {
    *
    * @param adventure adventure input
    * @return native representation
+   * @since 4.0.0
    */
   net.minecraft.network.chat.Component toNative(final Component adventure);
 
@@ -135,6 +143,7 @@ public interface FabricAudiences {
    *
    * @param vanilla the native component
    * @return adventure component
+   * @since 4.0.0
    */
   Component toAdventure(final net.minecraft.network.chat.Component vanilla);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
@@ -84,7 +84,7 @@ public interface FabricAudiences {
     if(loc == null) {
       return null;
     }
-    return Key.of(loc.getNamespace(), loc.getPath());
+    return Key.key(loc.getNamespace(), loc.getPath());
   }
 
   /**

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricClientAudienceProvider.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricClientAudienceProvider.java
@@ -28,17 +28,14 @@ import java.util.Locale;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.fabric.impl.client.FabricClientAudienceProviderImpl;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Access the client's player as an {@link net.kyori.adventure.audience.Audience}
  */
-public interface FabricClientAudienceProvider {
+public interface FabricClientAudienceProvider extends FabricAudiences {
 
   /**
    * Get the common instance, that will render using the global translation registry.
@@ -60,20 +57,11 @@ public interface FabricClientAudienceProvider {
   }
 
   /**
-   * Get an audience for the active player, if any is present.
+   * Get an audience for the client's player.
+   *
+   * <p>When not in-game, most operations will no-op</p>
    *
    * @return player audience
    */
-  default @Nullable Audience audience() {
-    final LocalPlayer player = Minecraft.getInstance().player;
-    return player == null ? null : this.audience(player);
-  }
-
-  /**
-   * Get an audience for the provided client's player.
-   *
-   * @param player player to send to
-   * @return player as an audience
-   */
-  Audience audience(final @NonNull LocalPlayer player);
+  @NonNull Audience audience();
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricClientAudienceProvider.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricClientAudienceProvider.java
@@ -33,7 +33,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Access the client's player as an {@link net.kyori.adventure.audience.Audience}
+ * Access the client's player as an {@link net.kyori.adventure.audience.Audience}.
+ *
+ * @since 4.0.0
  */
 public interface FabricClientAudienceProvider extends FabricAudiences {
 
@@ -41,6 +43,7 @@ public interface FabricClientAudienceProvider extends FabricAudiences {
    * Get the common instance, that will render using the global translation registry.
    *
    * @return the audience provider
+   * @since 4.0.0
    */
   static FabricClientAudienceProvider of() {
     return FabricClientAudienceProviderImpl.INSTANCE;
@@ -51,6 +54,7 @@ public interface FabricClientAudienceProvider extends FabricAudiences {
    *
    * @param renderer Renderer to use
    * @return new audience provider
+   * @since 4.0.0
    */
   static FabricClientAudienceProvider of(final ComponentRenderer<Locale> renderer) {
     return new FabricClientAudienceProviderImpl(requireNonNull(renderer, "renderer"));
@@ -62,6 +66,7 @@ public interface FabricClientAudienceProvider extends FabricAudiences {
    * <p>When not in-game, most operations will no-op</p>
    *
    * @return player audience
+   * @since 4.0.0
    */
   @NonNull Audience audience();
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric;
+
+import static java.util.Objects.requireNonNull;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.platform.AudienceProvider;
+import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudienceProviderImpl;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
+import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Locale;
+
+public interface FabricServerAudienceProvider extends AudienceProvider, FabricAudiences {
+
+  static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server) {
+    return new FabricServerAudienceProviderImpl(requireNonNull(server, "server"), TranslatableComponentRenderer.get());
+  }
+
+  static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server, @NonNull ComponentRenderer<Locale> renderer) {
+    return new FabricServerAudienceProviderImpl(requireNonNull(server, "server"), requireNonNull(renderer, "renderer"));
+  }
+
+  /**
+   * Get an audience to send to a {@link CommandSourceStack}.
+   *
+   * This will delegate to the native implementation by the command source, or
+   * otherwise use a wrapping implementation.
+   *
+   * @param source source to send to.
+   * @return the audience
+   */
+  AdventureCommandSourceStack audience(@NonNull CommandSourceStack source);
+
+  Audience audience(@NonNull CommandSource output);
+
+  Audience audience(@NonNull Iterable<ServerPlayer> players);
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
@@ -29,8 +29,8 @@ import static java.util.Objects.requireNonNull;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.AudienceProvider;
 import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudienceProviderImpl;
+import net.kyori.adventure.platform.fabric.impl.server.MinecraftServerBridge;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
-import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
@@ -42,7 +42,7 @@ import java.util.Locale;
 public interface FabricServerAudienceProvider extends AudienceProvider, FabricAudiences {
 
   static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server) {
-    return new FabricServerAudienceProviderImpl(requireNonNull(server, "server"), TranslatableComponentRenderer.get());
+    return ((MinecraftServerBridge) server).adventure$globalProvider();
   }
 
   static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server, @NonNull ComponentRenderer<Locale> renderer) {

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricServerAudienceProvider.java
@@ -39,12 +39,36 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Locale;
 
+/**
+ * Provides {@link Audience} instances for a specific server instance.
+ *
+ * @since 4.0.0
+ */
 public interface FabricServerAudienceProvider extends AudienceProvider, FabricAudiences {
 
+  /**
+   * Get the shared audience provider for the server.
+   *
+   * <p>This provider will render messages using the global translation registry.</p>
+   *
+   * @param server server instance to work with
+   * @return common audience provider
+   * @since 4.0.0
+   */
   static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server) {
     return ((MinecraftServerBridge) server).adventure$globalProvider();
   }
 
+  /**
+   * Get a customized audience provider for the server.
+   *
+   * <p>This provider will render messages using the global translation registry.</p>
+   *
+   * @param server server to work in
+   * @param renderer renderer for messages.
+   * @return new audience provider
+   * @since 4.0.0
+   */
   static @NonNull FabricServerAudienceProvider of(@NonNull MinecraftServer server, @NonNull ComponentRenderer<Locale> renderer) {
     return new FabricServerAudienceProviderImpl(requireNonNull(server, "server"), requireNonNull(renderer, "renderer"));
   }
@@ -57,10 +81,28 @@ public interface FabricServerAudienceProvider extends AudienceProvider, FabricAu
    *
    * @param source source to send to.
    * @return the audience
+   * @since 4.0.0
    */
   AdventureCommandSourceStack audience(@NonNull CommandSourceStack source);
 
-  Audience audience(@NonNull CommandSource output);
+  /**
+   * Get an audience that will send to the provided {@link CommandSource}.
+   *
+   * <p>Depending on the specific source, the returned audience may only support
+   * a subset of abilities.</p>
+   *
+   * @param source source to send to
+   * @return an audience for the source
+   * @since 4.0.0
+   */
+  Audience audience(@NonNull CommandSource source);
 
+  /**
+   * Create an audience that will send to every listed player.
+   *
+   * @param players Players to send to.
+   * @return a new audience
+   * @since 4.0.0
+   */
   Audience audience(@NonNull Iterable<ServerPlayer> players);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
@@ -51,6 +51,6 @@ public final class KeyArgumentType implements ArgumentType<Key> {
   @Override
   public Key parse(final StringReader reader) throws CommandSyntaxException {
     // TODO: do this without creating a ResourceLocation instance
-    return FabricAudienceProvider.adapt(ResourceLocation.read(reader));
+    return FabricAudiences.toAdventure(ResourceLocation.read(reader));
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/KeyArgumentType.java
@@ -32,15 +32,31 @@ import net.kyori.adventure.key.Key;
 import net.minecraft.resources.ResourceLocation;
 
 /**
- * An argument that will be decoded as a Key
+ * An argument that will be decoded as a Key.
+ *
+ * @since 4.0.0
  */
 public final class KeyArgumentType implements ArgumentType<Key> {
   private static final KeyArgumentType INSTANCE = new KeyArgumentType();
 
+  /**
+   * Get an argument type instance for {@link Key}s.
+   *
+   * @return key argument type
+   * @since 4.0.0
+   */
   public static KeyArgumentType key() {
     return INSTANCE;
   }
 
+  /**
+   * Get a {@link Key}-typed value from a parsed {@link CommandContext}
+   *
+   * @param ctx context to get the value from
+   * @param id id the argument was taken from
+   * @return provided argument
+   * @since 4.0.0
+   */
   public static Key key(final CommandContext<?> ctx, final String id) {
     return ctx.getArgument(id, Key.class);
   }

--- a/src/main/java/net/kyori/adventure/platform/fabric/PlayerLocales.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/PlayerLocales.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric;
+
+import java.util.Locale;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.kyori.adventure.platform.fabric.impl.LocaleHolderBridge;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface PlayerLocales {
+  /**
+   * Registration for {@link Changed}
+   */
+  Event<PlayerLocales.Changed> CHANGED_EVENT = EventFactory.createArrayBacked(PlayerLocales.Changed.class, listeners -> (player, locale) -> {
+    for(final Changed event : listeners) {
+      event.onLocaleChanged(player, locale);
+    }
+  });
+
+  /**
+   * An event called when a player locale update is received.
+   *
+   * <p>This event is only called if the player locale has actually changed from its previous value.</p>
+   */
+  interface Changed {
+
+    /**
+     * Handle the locale change.
+     *
+     * @param player the player whose locale changed
+     * @param newLocale the new locale
+     */
+    void onLocaleChanged(final ServerPlayer player, final @Nullable Locale newLocale);
+  }
+
+  /**
+   * Get the active locale for a player, either on the server or client sides.
+   *
+   * <p>Will return the system-wide default value if the player has no locale set.</p>
+   *
+   * @param player the source of the locale
+   * @return Player locale
+   */
+  static Locale locale(final Player player) {
+    return player instanceof LocaleHolderBridge ? ((LocaleHolderBridge) player).adventure$locale() : Locale.getDefault();
+  }
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/PlayerLocales.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/PlayerLocales.java
@@ -32,9 +32,16 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * API for working with player locales.
+ *
+ * @since 4.0.0
+ */
 public interface PlayerLocales {
   /**
-   * Registration for {@link Changed}
+   * Registration for {@link Changed}.
+   *
+   * @since 4.0.0
    */
   Event<PlayerLocales.Changed> CHANGED_EVENT = EventFactory.createArrayBacked(PlayerLocales.Changed.class, listeners -> (player, locale) -> {
     for(final Changed event : listeners) {
@@ -46,6 +53,8 @@ public interface PlayerLocales {
    * An event called when a player locale update is received.
    *
    * <p>This event is only called if the player locale has actually changed from its previous value.</p>
+   *
+   * @since 4.0.0
    */
   interface Changed {
 
@@ -54,6 +63,7 @@ public interface PlayerLocales {
      *
      * @param player the player whose locale changed
      * @param newLocale the new locale
+     * @since 4.0.0
      */
     void onLocaleChanged(final ServerPlayer player, final @Nullable Locale newLocale);
   }
@@ -64,7 +74,8 @@ public interface PlayerLocales {
    * <p>Will return the system-wide default value if the player has no locale set.</p>
    *
    * @param player the source of the locale
-   * @return Player locale
+   * @return player locale
+   * @since 4.0.0
    */
   static Locale locale(final Player player) {
     return player instanceof LocaleHolderBridge ? ((LocaleHolderBridge) player).adventure$locale() : Locale.getDefault();

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AbstractBossBarListener.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AbstractBossBarListener.java
@@ -28,18 +28,23 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.platform.fabric.FabricAudienceProvider;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
 import net.kyori.adventure.text.Component;
 import net.minecraft.world.BossEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract class AbstractBossBarListener<T extends BossEvent> implements BossBar.Listener {
+  private final FabricAudiences controller;
   protected final Map<BossBar, T> bars = new IdentityHashMap<>();
+
+  protected AbstractBossBarListener(final FabricAudiences controller) {
+    this.controller = controller;
+  }
 
   @Override
   public void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
     if(!oldName.equals(newName)) {
-      this.minecraft(bar).setName(FabricAudienceProvider.adapt(newName));
+      this.minecraft(bar).setName(this.controller.toNative(newName));
     }
   }
 
@@ -89,7 +94,7 @@ public abstract class AbstractBossBarListener<T extends BossEvent> implements Bo
 
   protected T minecraftCreating(final @NonNull BossBar bar) {
     return this.bars.computeIfAbsent(bar, key -> {
-      final T ret = this.newBar(FabricAudienceProvider.adapt(key.name()),
+      final T ret = this.newBar(this.controller.toNative(key.name()),
         GameEnums.BOSS_BAR_COLOR.toMinecraft(key.color()),
         GameEnums.BOSS_BAR_OVERLAY.toMinecraft(key.overlay()));
 
@@ -99,5 +104,4 @@ public abstract class AbstractBossBarListener<T extends BossEvent> implements Bo
       return ret;
     });
   }
-
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommandSourceStackInternal.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommandSourceStackInternal.java
@@ -24,28 +24,25 @@
 
 package net.kyori.adventure.platform.fabric.impl;
 
-import net.kyori.adventure.platform.fabric.impl.accessor.ComponentSerializerAccess;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.minecraft.network.chat.MutableComponent;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.platform.fabric.AdventureCommandSourceStack;
+import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudienceProviderImpl;
+import net.minecraft.commands.CommandSource;
 
-public final class NonWrappingComponentSerializer implements ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> {
-  public static final NonWrappingComponentSerializer INSTANCE = new NonWrappingComponentSerializer();
+public interface AdventureCommandSourceStackInternal extends AdventureCommandSourceStack {
+  /**
+   * Set the audience to be delegated to
+   *
+   * @param wrapped wrapped audience
+   * @param controller controller to render with
+   * @return the wrapped audience
+   */
+  AdventureCommandSourceStack adventure$audience(final Audience wrapped, final FabricServerAudienceProviderImpl controller);
 
-  private NonWrappingComponentSerializer() {
-  }
-
-  @Override
-  public Component deserialize(final net.minecraft.network.chat.Component input) {
-    if(input instanceof WrappedComponent) {
-      return ((WrappedComponent) input).wrapped();
-    }
-
-    return ComponentSerializerAccess.getGSON().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(input), Component.class);
-  }
-
-  @Override
-  public MutableComponent serialize(final Component component) {
-    return net.minecraft.network.chat.Component.Serializer.fromJson(ComponentSerializerAccess.getGSON().toJsonTree(component));
-  }
+  /**
+   * The backing source for the command.
+   *
+   * @return backing source
+   */
+  CommandSource adventure$source();
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventureCommon.java
@@ -25,10 +25,22 @@
 package net.kyori.adventure.platform.fabric.impl;
 
 import ca.stellardrift.colonel.api.ServerArgumentType;
+import io.netty.channel.Channel;
+import java.util.function.Function;
+import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.kyori.adventure.platform.fabric.ComponentArgumentType;
 import net.kyori.adventure.platform.fabric.KeyArgumentType;
+import net.kyori.adventure.platform.fabric.PlayerLocales;
+import net.kyori.adventure.platform.fabric.impl.accessor.ConnectionAccess;
+import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudienceProviderImpl;
+import net.kyori.adventure.platform.fabric.impl.server.FriendlyByteBufBridge;
+import net.kyori.adventure.text.KeybindComponent;
+import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.commands.arguments.ComponentArgument;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.commands.synchronization.ArgumentTypes;
@@ -36,7 +48,21 @@ import net.minecraft.commands.synchronization.EmptyArgumentSerializer;
 import net.minecraft.resources.ResourceLocation;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class AdventureInit implements ModInitializer {
+public class AdventureCommon implements ModInitializer {
+
+  public static final PlainComponentSerializer PLAIN;
+  public static final GsonComponentSerializer GSON = GsonComponentSerializer.builder().legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.INSTANCE).build();
+
+  static {
+    final Function<KeybindComponent, String> keybindNamer;
+
+    if(FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+      keybindNamer = keybind -> KeyMapping.createNameSupplier(keybind.keybind()).get().getContents();
+    } else {
+      keybindNamer = KeybindComponent::keybind;
+    }
+    PLAIN = new PlainComponentSerializer(keybindNamer, trans -> new WrappedComponent(trans, TranslatableComponentRenderer.get()).getContents());
+  }
 
   static ResourceLocation res(final @NonNull String value) {
     return new ResourceLocation("adventure", value);
@@ -62,5 +88,13 @@ public class AdventureInit implements ModInitializer {
       ArgumentTypes.register("adventure:component", ComponentArgumentType.class, new ComponentArgumentTypeSerializer());
       ArgumentTypes.register("adventure:key", KeyArgumentType.class, new EmptyArgumentSerializer<>(KeyArgumentType::key));
     }
+
+    PlayerLocales.CHANGED_EVENT.register((player, locale) -> {
+      final Channel channel = ((ConnectionAccess) player.connection.getConnection()).getChannel();
+      channel.attr(FriendlyByteBufBridge.CHANNEL_LOCALE).set(locale);
+      FabricServerAudienceProviderImpl.forEachInstance(instance -> {
+        instance.bossBars().refreshTitles(player);
+      });
+    });
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/FriendlyByteBufBridge.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/FriendlyByteBufBridge.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl;
+
+import io.netty.util.AttributeKey;
+import java.util.Locale;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface FriendlyByteBufBridge {
+  AttributeKey<Locale> CHANNEL_LOCALE = AttributeKey.newInstance("adventure:locale");
+  void adventure$locale(final @Nullable Locale locale);
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/NBTLegacyHoverEventSerializer.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/NBTLegacyHoverEventSerializer.java
@@ -29,11 +29,11 @@ import java.io.IOException;
 import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
-import net.kyori.adventure.platform.fabric.FabricAudienceProvider;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.util.Codec;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -57,7 +57,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
 
   @Override
   public HoverEvent.@NonNull ShowItem deserializeShowItem(final @NonNull Component input) throws IOException {
-    final String raw = FabricAudienceProvider.plainSerializer().serialize(input);
+    final String raw = PlainComponentSerializer.plain().serialize(input);
     try {
       final CompoundTag contents = SNBT_CODEC.decode(raw);
       final CompoundTag tag = contents.getCompound(ITEM_TAG);
@@ -73,7 +73,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
 
   @Override
   public HoverEvent.@NonNull ShowEntity deserializeShowEntity(final @NonNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
-    final String raw = FabricAudienceProvider.plainSerializer().serialize(input);
+    final String raw = PlainComponentSerializer.plain().serialize(input);
     try {
       final CompoundTag contents = SNBT_CODEC.decode(raw);
       return HoverEvent.ShowEntity.of(

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/NBTLegacyHoverEventSerializer.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/NBTLegacyHoverEventSerializer.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
@@ -62,7 +61,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
       final CompoundTag contents = SNBT_CODEC.decode(raw);
       final CompoundTag tag = contents.getCompound(ITEM_TAG);
       return HoverEvent.ShowItem.of(
-        Key.of(contents.getString(ITEM_TYPE)),
+        Key.key(contents.getString(ITEM_TYPE)),
         contents.contains(ITEM_COUNT) ? contents.getByte(ITEM_COUNT) : 1,
         tag.isEmpty() ? null : BinaryTagHolder.encode(tag, SNBT_CODEC)
       );
@@ -77,7 +76,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
     try {
       final CompoundTag contents = SNBT_CODEC.decode(raw);
       return HoverEvent.ShowEntity.of(
-        Key.of(contents.getString(ENTITY_TYPE)),
+        Key.key(contents.getString(ENTITY_TYPE)),
         UUID.fromString(contents.getString(ENTITY_ID)),
         componentCodec.decode(contents.getString(ENTITY_NAME))
       );
@@ -99,7 +98,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
       }
     }
 
-    return TextComponent.of(SNBT_CODEC.encode(tag));
+    return Component.text(SNBT_CODEC.encode(tag));
   }
 
   @Override
@@ -110,6 +109,6 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
     if(input.name() != null) {
       tag.putString(ENTITY_NAME, componentCodec.encode(input.name()));
     }
-    return TextComponent.of(SNBT_CODEC.encode(tag));
+    return Component.text(SNBT_CODEC.encode(tag));
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/client/AdventureBookAccess.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/client/AdventureBookAccess.java
@@ -24,10 +24,13 @@
 
 package net.kyori.adventure.platform.fabric.impl.client;
 
+import java.util.Locale;
 import net.kyori.adventure.inventory.Book;
-import net.kyori.adventure.platform.fabric.FabricAudienceProvider;
+import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
 import net.minecraft.client.gui.screens.inventory.BookViewScreen;
 import net.minecraft.network.chat.FormattedText;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,9 +43,11 @@ import static java.util.Objects.requireNonNull;
  */
 public class AdventureBookAccess implements BookViewScreen.BookAccess {
   private final Book book;
+  private final @Nullable ComponentRenderer<Locale> renderer;
 
-  public AdventureBookAccess(final Book book) {
+  public AdventureBookAccess(final Book book, final @Nullable ComponentRenderer<Locale> renderer) {
     this.book = requireNonNull(book, "book");
+    this.renderer = renderer;
   }
 
   @Override
@@ -52,6 +57,6 @@ public class AdventureBookAccess implements BookViewScreen.BookAccess {
 
   @Override
   public FormattedText getPageRaw(final int index) {
-    return FabricAudienceProvider.adapt(this.book.pages().get(index));
+    return new WrappedComponent(this.book.pages().get(index), this.renderer);
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/client/BossHealthOverlayBridge.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/client/BossHealthOverlayBridge.java
@@ -34,9 +34,9 @@ import net.minecraft.client.gui.components.BossHealthOverlay;
  * Accessor for our listener stored in the client HUD.
  */
 public interface BossHealthOverlayBridge {
-  ClientBossBarListener adventure$listener();
+  ClientBossBarListener adventure$listener(final @NonNull FabricClientAudienceProviderImpl controller);
 
-  static ClientBossBarListener listener(final @NonNull BossHealthOverlay hud) {
-    return ((BossHealthOverlayBridge) requireNonNull(hud, "hud")).adventure$listener();
+  static ClientBossBarListener listener(final @NonNull BossHealthOverlay hud, final @NonNull FabricClientAudienceProviderImpl controller) {
+    return ((BossHealthOverlayBridge) requireNonNull(hud, "hud")).adventure$listener(controller);
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientAudience.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.client;
+
+import java.time.Duration;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
+import net.kyori.adventure.platform.fabric.impl.GameEnums;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.title.Title;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.BookViewScreen;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.client.resources.sounds.SoundInstance;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.ChatVisiblity;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class ClientAudience implements Audience {
+  private final Minecraft client;
+  private final FabricClientAudienceProviderImpl controller;
+
+  public ClientAudience(final Minecraft client, final FabricClientAudienceProviderImpl renderer) {
+    this.client = client;
+    this.controller = renderer;
+  }
+
+  @Override
+  public void sendMessage(final @NonNull Component message, final @NonNull MessageType type) {
+    final ChatVisiblity visibility = this.client.options.chatVisibility;
+    if(type == MessageType.CHAT) {
+      // Add to chat queue (following delay and such)
+      if(visibility == ChatVisiblity.FULL) {
+        this.client.gui.getChat().enqueueMessage(this.controller.toNative(message));
+      }
+    } else {
+      // Add immediately as a system message
+      if(visibility == ChatVisiblity.FULL || visibility == ChatVisiblity.SYSTEM) {
+        this.client.gui.getChat().addMessage(this.controller.toNative(message));
+      }
+    }
+  }
+
+  @Override
+  public void sendActionBar(final @NonNull Component message) {
+    this.client.gui.setOverlayMessage(this.controller.toNative(message), false);
+  }
+
+  @Override
+  public void showTitle(final @NonNull Title title) {
+    final /* @Nullable */ net.minecraft.network.chat.Component titleText = title.title() == TextComponent.empty() ? null : this.controller.toNative(title.title());
+    final /* @Nullable */ net.minecraft.network.chat.Component subtitleText = title.subtitle() == TextComponent.empty() ? null : this.controller.toNative(title.subtitle());
+    final /* @Nullable */ Title.Times times = title.times();
+    this.client.gui.setTitles(titleText, subtitleText,
+      this.adventure$ticks(times == null ? null : times.fadeIn()),
+      this.adventure$ticks(times == null ? null : times.stay()),
+      this.adventure$ticks(times == null ? null : times.fadeOut()));
+  }
+
+  private int adventure$ticks(final @Nullable Duration duration) {
+    return duration == null || duration.getSeconds() == -1 ? -1 : (int) (duration.toMillis() / 50);
+  }
+
+  @Override
+  public void clearTitle() {
+    this.client.gui.setTitles(null, null, -1, -1, -1);
+  }
+
+  @Override
+  public void resetTitle() {
+    this.client.gui.resetTitleTimes();
+  }
+
+  @Override
+  public void showBossBar(final @NonNull BossBar bar) {
+    BossHealthOverlayBridge.listener(this.client.gui.getBossOverlay(), this.controller).add(bar);
+  }
+
+  @Override
+  public void hideBossBar(final @NonNull BossBar bar) {
+    BossHealthOverlayBridge.listener(this.client.gui.getBossOverlay(), this.controller).remove(bar);
+  }
+
+  @Override
+  public void playSound(final @NonNull Sound sound) {
+    final LocalPlayer player = this.client.player;
+    if(player != null) {
+      this.playSound(sound, player.getX(), player.getY(), player.getZ());
+    } else {
+      // not in-game
+      this.client.getSoundManager().play(new SimpleSoundInstance(FabricAudiences.toNative(sound.name()), GameEnums.SOUND_SOURCE.toMinecraft(sound.source()),
+        sound.volume(), sound.pitch(), false, 0, SoundInstance.Attenuation.NONE, 0, 0, 0, true));
+    }
+  }
+
+  @Override
+  public void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
+    this.client.getSoundManager().play(new SimpleSoundInstance(FabricAudiences.toNative(sound.name()), GameEnums.SOUND_SOURCE.toMinecraft(sound.source()),
+      sound.volume(), sound.pitch(), false, 0, SoundInstance.Attenuation.LINEAR, x, y, z, false));
+  }
+
+  @Override
+  public void stopSound(final @NonNull SoundStop stop) {
+    final /* @Nullable */ Key sound = stop.sound();
+    final /* @Nullable */ ResourceLocation soundIdent = sound == null ? null : FabricAudiences.toNative(sound);
+    final Sound./* @Nullable */ Source source = stop.source();
+    final /* @Nullable */ SoundSource category = source == null ? null : GameEnums.SOUND_SOURCE.toMinecraft(source);
+    this.client.getSoundManager().stop(soundIdent, category);
+  }
+
+  @Override
+  public void openBook(final @NonNull Book book) {
+    this.client.setScreen(new BookViewScreen(new AdventureBookAccess(book, this.controller.localeRenderer())));
+  }
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientAudience.java
@@ -35,7 +35,6 @@ import net.kyori.adventure.platform.fabric.impl.GameEnums;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.title.Title;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.BookViewScreen;
@@ -80,8 +79,8 @@ public class ClientAudience implements Audience {
 
   @Override
   public void showTitle(final @NonNull Title title) {
-    final /* @Nullable */ net.minecraft.network.chat.Component titleText = title.title() == TextComponent.empty() ? null : this.controller.toNative(title.title());
-    final /* @Nullable */ net.minecraft.network.chat.Component subtitleText = title.subtitle() == TextComponent.empty() ? null : this.controller.toNative(title.subtitle());
+    final /* @Nullable */ net.minecraft.network.chat.Component titleText = title.title() == Component.empty() ? null : this.controller.toNative(title.title());
+    final /* @Nullable */ net.minecraft.network.chat.Component subtitleText = title.subtitle() == Component.empty() ? null : this.controller.toNative(title.subtitle());
     final /* @Nullable */ Title.Times times = title.times();
     this.client.gui.setTitles(titleText, subtitleText,
       this.adventure$ticks(times == null ? null : times.fadeIn()),

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientBossBarListener.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/client/ClientBossBarListener.java
@@ -38,7 +38,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public class ClientBossBarListener extends AbstractBossBarListener<LerpingBossEvent> {
   private final Map<UUID, LerpingBossEvent> hudBars;
 
-  public ClientBossBarListener(final Map<UUID, LerpingBossEvent> hudBars) {
+  public ClientBossBarListener(final FabricClientAudienceProviderImpl controller, final Map<UUID, LerpingBossEvent> hudBars) {
+    super(controller);
     this.hudBars = hudBars;
   }
 
@@ -67,8 +68,9 @@ public class ClientBossBarListener extends AbstractBossBarListener<LerpingBossEv
   }
 
   public void clear() {
-    for(final BossBar bar : this.bars.keySet()) {
-      bar.removeListener(this);
+    for(final Map.Entry<BossBar, LerpingBossEvent> entry : this.bars.entrySet()) {
+      entry.getKey().removeListener(this);
+      this.hudBars.remove(entry.getValue().getId());
     }
     this.bars.clear();
   }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/CommandSourceAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/CommandSourceAudience.java
@@ -22,37 +22,31 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric;
+package net.kyori.adventure.platform.fabric.impl.server;
 
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
 import net.kyori.adventure.text.Component;
 import net.minecraft.Util;
 import net.minecraft.commands.CommandSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import static java.util.Objects.requireNonNull;
-
 /**
- * Audience implementation that can wrap a CommandOutput
+ * Audience implementation that can wrap a {@link CommandSource}
  */
-public final class CommandSourceAudience implements Audience {
+final class CommandSourceAudience implements Audience {
   private final CommandSource output;
+  private final FabricAudiences serializer;
 
-  CommandSourceAudience(final CommandSource output) {
+  CommandSourceAudience(final CommandSource output, final FabricAudiences serializer) {
     this.output = output;
-  }
-
-  public static Audience of(final CommandSource output) {
-    if(output instanceof Audience) {
-      return (Audience) output;
-    } else {
-      return new CommandSourceAudience(requireNonNull(output, "output"));
-    }
+    this.serializer = serializer;
   }
 
   @Override
-  public void sendMessage(final Component text) {
-    this.output.sendMessage(FabricAudienceProvider.adapt(text), Util.NIL_UUID);
+  public void sendMessage(final Component text, final MessageType type) {
+    this.output.sendMessage(this.serializer.toNative(text), Util.NIL_UUID);
   }
 
   @Override

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FabricServerAudienceProviderImpl.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FabricServerAudienceProviderImpl.java
@@ -136,14 +136,14 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
     return internal.adventure$audience(this.audience(internal.adventure$source()), this);
   }
 
-  @Override public Audience audience(final @NonNull CommandSource output) {
-    if(output instanceof RenderableAudience) {
-      return ((RenderableAudience) output).renderUsing(this);
-    } else if(output instanceof Audience) {
+  @Override public Audience audience(final @NonNull CommandSource source) {
+    if(source instanceof RenderableAudience) {
+      return ((RenderableAudience) source).renderUsing(this);
+    } else if(source instanceof Audience) {
       // TODO: How to pass component renderer through
-      return (Audience) output;
+      return (Audience) source;
     } else {
-      return new CommandSourceAudience(output, this);
+      return new CommandSourceAudience(source, this);
     }
   }
 

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FabricServerAudienceProviderImpl.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FabricServerAudienceProviderImpl.java
@@ -99,7 +99,7 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
 
   @Override
   public @NonNull Audience all() {
-    return Audience.of(this.console(), this.players());
+    return Audience.audience(this.console(), this.players());
   }
 
   @Override
@@ -109,7 +109,7 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
 
   @Override
   public @NonNull Audience players() {
-    return Audience.of(this.audiences(this.server.getPlayerList().getPlayers()));
+    return Audience.audience(this.audiences(this.server.getPlayerList().getPlayers()));
   }
 
   @Override
@@ -124,7 +124,7 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
 
   @Override
   public @NonNull Audience permission(final @NonNull String permission) {
-    return Audience.of(); // TODO: permissions api
+    return Audience.empty(); // TODO: permissions api
   }
 
   @Override public AdventureCommandSourceStack audience(final @NonNull CommandSourceStack source) {
@@ -148,7 +148,7 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
   }
 
   @Override public Audience audience(final @NonNull Iterable<ServerPlayer> players) {
-    return Audience.of(this.audiences(players));
+    return Audience.audience(this.audiences(players));
   }
 
   @Override
@@ -158,7 +158,7 @@ public final class FabricServerAudienceProviderImpl implements FabricServerAudie
     if(level != null) {
       return this.audience(level.players());
     }
-    return Audience.of();
+    return Audience.empty();
   }
 
   @Override

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FriendlyByteBufBridge.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FriendlyByteBufBridge.java
@@ -22,30 +22,13 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric.impl;
+package net.kyori.adventure.platform.fabric.impl.server;
 
-import net.kyori.adventure.platform.fabric.impl.accessor.ComponentSerializerAccess;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.minecraft.network.chat.MutableComponent;
+import io.netty.util.AttributeKey;
+import java.util.Locale;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-public final class NonWrappingComponentSerializer implements ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> {
-  public static final NonWrappingComponentSerializer INSTANCE = new NonWrappingComponentSerializer();
-
-  private NonWrappingComponentSerializer() {
-  }
-
-  @Override
-  public Component deserialize(final net.minecraft.network.chat.Component input) {
-    if(input instanceof WrappedComponent) {
-      return ((WrappedComponent) input).wrapped();
-    }
-
-    return ComponentSerializerAccess.getGSON().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(input), Component.class);
-  }
-
-  @Override
-  public MutableComponent serialize(final Component component) {
-    return net.minecraft.network.chat.Component.Serializer.fromJson(ComponentSerializerAccess.getGSON().toJsonTree(component));
-  }
+public interface FriendlyByteBufBridge {
+  AttributeKey<Locale> CHANNEL_LOCALE = AttributeKey.newInstance("adventure:locale");
+  void adventure$locale(final @Nullable Locale locale);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/MinecraftServerBridge.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/MinecraftServerBridge.java
@@ -22,30 +22,11 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric.impl;
+package net.kyori.adventure.platform.fabric.impl.server;
 
-import net.kyori.adventure.platform.fabric.impl.accessor.ComponentSerializerAccess;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.minecraft.network.chat.MutableComponent;
+import net.kyori.adventure.platform.fabric.FabricServerAudienceProvider;
 
-public final class NonWrappingComponentSerializer implements ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> {
-  public static final NonWrappingComponentSerializer INSTANCE = new NonWrappingComponentSerializer();
+public interface MinecraftServerBridge {
 
-  private NonWrappingComponentSerializer() {
-  }
-
-  @Override
-  public Component deserialize(final net.minecraft.network.chat.Component input) {
-    if(input instanceof WrappedComponent) {
-      return ((WrappedComponent) input).wrapped();
-    }
-
-    return ComponentSerializerAccess.getGSON().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(input), Component.class);
-  }
-
-  @Override
-  public MutableComponent serialize(final Component component) {
-    return net.minecraft.network.chat.Component.Serializer.fromJson(ComponentSerializerAccess.getGSON().toJsonTree(component));
-  }
+  FabricServerAudienceProvider adventure$globalProvider();
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/PlainAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/PlainAudience.java
@@ -22,30 +22,31 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric.impl;
+package net.kyori.adventure.platform.fabric.impl.server;
 
-import net.kyori.adventure.platform.fabric.impl.accessor.ComponentSerializerAccess;
+import java.util.function.Consumer;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.minecraft.network.chat.MutableComponent;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-public final class NonWrappingComponentSerializer implements ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> {
-  public static final NonWrappingComponentSerializer INSTANCE = new NonWrappingComponentSerializer();
+public class PlainAudience implements Audience {
+  private final FabricAudiences controller;
+  private final Consumer<String> plainOutput;
 
-  private NonWrappingComponentSerializer() {
+  public PlainAudience(final FabricAudiences controller, final Consumer<String> plainOutput) {
+    this.controller = controller;
+    this.plainOutput = plainOutput;
   }
 
   @Override
-  public Component deserialize(final net.minecraft.network.chat.Component input) {
-    if(input instanceof WrappedComponent) {
-      return ((WrappedComponent) input).wrapped();
-    }
-
-    return ComponentSerializerAccess.getGSON().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(input), Component.class);
+  public void sendMessage(final @NonNull Component message, final @NonNull MessageType type) {
+    this.plainOutput.accept(this.controller.plainSerializer().serialize(message));
   }
 
   @Override
-  public MutableComponent serialize(final Component component) {
-    return net.minecraft.network.chat.Component.Serializer.fromJson(ComponentSerializerAccess.getGSON().toJsonTree(component));
+  public void sendActionBar(final @NonNull Component message) {
+    this.sendMessage(message);
   }
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/RenderableAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/RenderableAudience.java
@@ -22,13 +22,10 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric.impl;
+package net.kyori.adventure.platform.fabric.impl.server;
 
-import io.netty.util.AttributeKey;
-import java.util.Locale;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import net.kyori.adventure.audience.Audience;
 
-public interface FriendlyByteBufBridge {
-  AttributeKey<Locale> CHANNEL_LOCALE = AttributeKey.newInstance("adventure:locale");
-  void adventure$locale(final @Nullable Locale locale);
+public interface RenderableAudience extends Audience {
+  Audience renderUsing(final FabricServerAudienceProviderImpl controller);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerBossEventBridge.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerBossEventBridge.java
@@ -31,9 +31,9 @@ import net.minecraft.server.level.ServerPlayer;
  * An interface for performing bulk adds and removes on a {@link net.minecraft.server.level.ServerBossEvent}
  */
 public interface ServerBossEventBridge {
-  void addAll(Collection<ServerPlayer> players);
+  void adventure$addAll(Collection<ServerPlayer> players);
 
-  void removeAll(Collection<ServerPlayer> players);
+  void adventure$removeAll(Collection<ServerPlayer> players);
 
-  void replaceSubscriber(ServerPlayer oldSub, ServerPlayer newSub);
+  void adventure$replaceSubscriber(ServerPlayer oldSub, ServerPlayer newSub);
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerPlayerAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerPlayerAudience.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.server;
+
+import java.time.Duration;
+import java.util.Locale;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
+import net.kyori.adventure.platform.fabric.impl.GameEnums;
+import net.kyori.adventure.platform.fabric.impl.accessor.ConnectionAccess;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.title.Title;
+import net.minecraft.Util;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundChatPacket;
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
+import net.minecraft.network.protocol.game.ClientboundCustomSoundPacket;
+import net.minecraft.network.protocol.game.ClientboundSetTitlesPacket;
+import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.ChatVisiblity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.phys.Vec3;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public final class ServerPlayerAudience implements Audience {
+  private final ServerPlayer player;
+  private final FabricServerAudienceProviderImpl controller;
+
+  public ServerPlayerAudience(final ServerPlayer player, final FabricServerAudienceProviderImpl controller) {
+    this.player = player;
+    this.controller = controller;
+  }
+
+  void sendPacket(final Packet<?> packet) {
+    this.player.connection.send(packet);
+  }
+
+  @Override
+  public void sendMessage(final Component text, final net.kyori.adventure.audience.MessageType type) {
+    final ChatType mcType;
+    final boolean shouldSend;
+    if(type == net.kyori.adventure.audience.MessageType.CHAT) {
+      mcType = ChatType.CHAT;
+      shouldSend = this.player.getChatVisibility() == ChatVisiblity.FULL;
+    } else {
+      mcType = ChatType.SYSTEM;
+      shouldSend = this.player.getChatVisibility() == ChatVisiblity.FULL || this.player.getChatVisibility() == ChatVisiblity.SYSTEM;
+    }
+
+    if(shouldSend) {
+      this.sendPacket(new ClientboundChatPacket(this.controller.toNative(text), mcType, Util.NIL_UUID));
+    }
+  }
+
+  @Override
+  public void sendActionBar(final @NonNull Component message) {
+    this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.ACTIONBAR, this.controller.toNative(message)));
+  }
+
+  @Override
+  public void showBossBar(final @NonNull BossBar bar) {
+    FabricServerAudienceProviderImpl.forEachInstance(controller -> {
+      if(controller != this.controller) {
+        controller.bossBars.unsubscribe(this.player, bar);
+      }
+    });
+    this.controller.bossBars.subscribe(this.player, bar);
+  }
+
+  @Override
+  public void hideBossBar(final @NonNull BossBar bar) {
+    FabricServerAudienceProviderImpl.forEachInstance(controller -> controller.bossBars.unsubscribe(this.player, bar));
+  }
+
+  @Override
+  public void playSound(final @NonNull Sound sound) {
+    this.sendPacket(new ClientboundCustomSoundPacket(FabricAudiences.toNative(sound.name()),
+      GameEnums.SOUND_SOURCE.toMinecraft(sound.source()), this.player.position(), sound.volume(), sound.pitch()));
+  }
+
+  @Override
+  public void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
+    this.sendPacket(new ClientboundCustomSoundPacket(FabricAudiences.toNative(sound.name()),
+      GameEnums.SOUND_SOURCE.toMinecraft(sound.source()), new Vec3(x, y, z), sound.volume(), sound.pitch()));
+  }
+
+  @Override
+  public void stopSound(final @NonNull SoundStop stop) {
+    final /* @Nullable */ Key sound = stop.sound();
+    final Sound./* @Nullable */ Source src = stop.source();
+    final /* @Nullable */ SoundSource cat = src == null ? null : GameEnums.SOUND_SOURCE.toMinecraft(src);
+    this.sendPacket(new ClientboundStopSoundPacket(sound == null ? null : FabricAudiences.toNative(sound), cat));
+  }
+
+  static final String BOOK_TITLE = "title";
+  static final String BOOK_AUTHOR = "author";
+  static final String BOOK_PAGES = "pages";
+  static final String BOOK_RESOLVED = "resolved";
+
+  @Override
+  public void openBook(final @NonNull Book book) {
+    final ItemStack bookStack = new ItemStack(Items.WRITTEN_BOOK, 1);
+    final CompoundTag bookTag = bookStack.getOrCreateTag();
+    bookTag.putString(BOOK_TITLE, this.adventure$serialize(book.title()));
+    bookTag.putString(BOOK_AUTHOR, this.adventure$serialize(book.author()));
+    final ListTag pages = new ListTag();
+    for(final Component page : book.pages()) {
+      pages.add(StringTag.valueOf(this.adventure$serialize(page)));
+    }
+    bookTag.put(BOOK_PAGES, pages);
+    bookTag.putBoolean(BOOK_RESOLVED, true); // todo: any parseable texts?
+
+    final ItemStack previous = this.player.inventory.getSelected();
+    this.sendPacket(new ClientboundContainerSetSlotPacket(-2, this.player.inventory.selected, bookStack));
+    this.player.openItemGui(bookStack, InteractionHand.MAIN_HAND);
+    this.sendPacket(new ClientboundContainerSetSlotPacket(-2, this.player.inventory.selected, previous));
+  }
+
+  private String adventure$serialize(final @NonNull Component component) {
+    final Locale locale = ((ConnectionAccess) this.player.connection).getChannel().attr(FriendlyByteBufBridge.CHANNEL_LOCALE).get();
+    return this.controller.gsonSerializer().serialize(this.controller.localeRenderer().render(component, locale == null ? Locale.getDefault() : locale));
+  }
+
+  @Override
+  public void showTitle(final @NonNull Title title) {
+    if(title.subtitle() != TextComponent.empty()) {
+      this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.SUBTITLE, this.controller.toNative(title.subtitle())));
+    }
+
+    final /* @Nullable */ Title.Times times = title.times();
+    if(times != null) {
+      final int fadeIn = ticks(times.fadeIn());
+      final int fadeOut = ticks(times.fadeOut());
+      final int dwell = ticks(times.stay());
+      if(fadeIn != -1 || fadeOut != -1 || dwell != -1) {
+        this.sendPacket(new ClientboundSetTitlesPacket(fadeIn, dwell, fadeOut));
+      }
+    }
+
+    if(title.title() != TextComponent.empty()) {
+      this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.TITLE, this.controller.toNative(title.title())));
+    }
+  }
+
+  static int ticks(final @NonNull Duration duration) {
+    return duration.getSeconds() == -1 ? -1 : (int) (duration.toMillis() / 50);
+  }
+
+  @Override
+  public void clearTitle() {
+    this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.CLEAR, null));
+  }
+
+  @Override
+  public void resetTitle() {
+    this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.RESET, null));
+  }
+
+}

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerPlayerAudience.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/ServerPlayerAudience.java
@@ -36,7 +36,6 @@ import net.kyori.adventure.platform.fabric.impl.accessor.ConnectionAccess;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.title.Title;
 import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
@@ -159,7 +158,7 @@ public final class ServerPlayerAudience implements Audience {
 
   @Override
   public void showTitle(final @NonNull Title title) {
-    if(title.subtitle() != TextComponent.empty()) {
+    if(title.subtitle() != Component.empty()) {
       this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.SUBTITLE, this.controller.toNative(title.subtitle())));
     }
 
@@ -173,7 +172,7 @@ public final class ServerPlayerAudience implements Audience {
       }
     }
 
-    if(title.title() != TextComponent.empty()) {
+    if(title.title() != Component.empty()) {
       this.sendPacket(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.TITLE, this.controller.toNative(title.title())));
     }
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
   "entrypoints": {
     "main": [
       {
-        "value":"net.kyori.adventure.platform.fabric.impl.AdventureInit"
+        "value":"net.kyori.adventure.platform.fabric.impl.AdventureCommon"
       }
     ]
   },
@@ -31,7 +31,8 @@
   },
 
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.4.0",
+    "fabric-api-base": "*"
   },
 
   "recommends": {

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ComponentSerializerMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ComponentSerializerMixin.java
@@ -30,7 +30,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
 import java.lang.reflect.Type;
 
-import net.kyori.adventure.platform.fabric.impl.FabricAudienceProviderImpl;
+import net.kyori.adventure.platform.fabric.impl.AdventureCommon;
 import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
 import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
@@ -60,6 +60,6 @@ public abstract class ComponentSerializerMixin {
   @Inject(method = "*()Lcom/google/gson/Gson;", at = @At(value = "INVOKE_ASSIGN", target = "com/google/gson/GsonBuilder.disableHtmlEscaping()Lcom/google/gson/GsonBuilder;", remap = false),
     locals = LocalCapture.CAPTURE_FAILEXCEPTION, remap = false)
   private static void injectAdventureGson(final CallbackInfoReturnable<Gson> cir, final GsonBuilder gson) {
-    FabricAudienceProviderImpl.GSON.populator().apply(gson);
+    AdventureCommon.GSON.populator().apply(gson);
   }
 }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/FriendlyByteBufMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/FriendlyByteBufMixin.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.mixin;
+
+import java.util.Locale;
+import net.kyori.adventure.platform.fabric.impl.FriendlyByteBufBridge;
+import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(FriendlyByteBuf.class)
+public class FriendlyByteBufMixin implements FriendlyByteBufBridge {
+  private @Nullable Locale adventure$locale;
+
+  @ModifyVariable(method = "writeComponent", at = @At("HEAD"), argsOnly = true)
+  private Component localizeComponent(final Component input) {
+    if(this.adventure$locale != null && input instanceof WrappedComponent) {
+      return ((WrappedComponent) input).rendered(this.adventure$locale);
+    }
+    return input;
+  }
+
+  @Override
+  public void adventure$locale(final @Nullable Locale locale) {
+    this.adventure$locale = locale;
+  }
+}

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/FriendlyByteBufMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/FriendlyByteBufMixin.java
@@ -25,7 +25,7 @@
 package net.kyori.adventure.platform.fabric.impl.mixin;
 
 import java.util.Locale;
-import net.kyori.adventure.platform.fabric.impl.FriendlyByteBufBridge;
+import net.kyori.adventure.platform.fabric.impl.server.FriendlyByteBufBridge;
 import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/PacketEncoderMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/PacketEncoderMixin.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.platform.fabric.impl.mixin;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import net.kyori.adventure.platform.fabric.impl.FriendlyByteBufBridge;
+import net.kyori.adventure.platform.fabric.impl.server.FriendlyByteBufBridge;
 import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.PacketEncoder;

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/PacketEncoderMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/PacketEncoderMixin.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.kyori.adventure.platform.fabric.impl.mixin;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import net.kyori.adventure.platform.fabric.impl.FriendlyByteBufBridge;
+import net.minecraft.network.ConnectionProtocol;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.PacketEncoder;
+import net.minecraft.network.protocol.Packet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(PacketEncoder.class)
+public class PacketEncoderMixin {
+  @Inject(method = "encode", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/FriendlyByteBuf;writeVarInt(I)Lnet/minecraft/network/FriendlyByteBuf;"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void applyLocaleToBuffer(final ChannelHandlerContext ctx, final Packet<?> pkt, final ByteBuf orig, final CallbackInfo ci, final ConnectionProtocol unused$proto, final Integer unused$id, final FriendlyByteBuf buffer) {
+    ((FriendlyByteBufBridge) buffer).adventure$locale(ctx.channel().attr(FriendlyByteBufBridge.CHANNEL_LOCALE).get());
+  }
+}

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ServerBossEventMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ServerBossEventMixin.java
@@ -78,7 +78,7 @@ public abstract class ServerBossEventMixin extends BossEvent implements ServerBo
   }
 
   @Override
-  public void addAll(final Collection<ServerPlayer> players) {
+  public void adventure$addAll(final Collection<ServerPlayer> players) {
     final ClientboundBossEventPacket pkt = new ClientboundBossEventPacket(ClientboundBossEventPacket.Operation.ADD, this);
     for(final ServerPlayer player : players) {
       if(this.players.add(player) && this.isVisible()) {
@@ -88,7 +88,7 @@ public abstract class ServerBossEventMixin extends BossEvent implements ServerBo
   }
 
   @Override
-  public void removeAll(final Collection<ServerPlayer> players) {
+  public void adventure$removeAll(final Collection<ServerPlayer> players) {
     final ClientboundBossEventPacket pkt = new ClientboundBossEventPacket(ClientboundBossEventPacket.Operation.REMOVE, this);
     for(final ServerPlayer player : players) {
       if(this.players.remove(player) && this.isVisible()) {
@@ -98,7 +98,7 @@ public abstract class ServerBossEventMixin extends BossEvent implements ServerBo
   }
 
   @Override
-  public void replaceSubscriber(final ServerPlayer oldSub, final ServerPlayer newSub) {
+  public void adventure$replaceSubscriber(final ServerPlayer oldSub, final ServerPlayer newSub) {
     if(this.players.remove(oldSub)) {
       this.players.add(newSub);
     }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ServerPlayerMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/ServerPlayerMixin.java
@@ -24,50 +24,30 @@
 
 package net.kyori.adventure.platform.fabric.impl.mixin;
 
+import com.google.common.collect.MapMaker;
 import com.mojang.authlib.GameProfile;
-import io.netty.channel.Channel;
-import java.time.Duration;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.inventory.Book;
-import net.kyori.adventure.key.Key;
-import net.kyori.adventure.platform.fabric.FabricAudienceProvider;
-import net.kyori.adventure.platform.fabric.impl.FriendlyByteBufBridge;
-import net.kyori.adventure.platform.fabric.impl.GameEnums;
-import net.kyori.adventure.platform.fabric.impl.accessor.ConnectionAccess;
+import net.kyori.adventure.audience.ForwardingAudience;
+import net.kyori.adventure.platform.fabric.FabricServerAudienceProvider;
+import net.kyori.adventure.platform.fabric.impl.LocaleHolderBridge;
+import net.kyori.adventure.platform.fabric.PlayerLocales;
 import net.kyori.adventure.platform.fabric.impl.accessor.ServerboundClientInformationPacketAccess;
-import net.kyori.adventure.platform.fabric.impl.server.ServerBossBarListener;
-import net.kyori.adventure.sound.Sound;
-import net.kyori.adventure.sound.SoundStop;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.title.Title;
-import net.minecraft.Util;
+import net.kyori.adventure.platform.fabric.impl.server.FabricServerAudienceProviderImpl;
+import net.kyori.adventure.platform.fabric.impl.server.RenderableAudience;
+import net.kyori.adventure.platform.fabric.impl.server.ServerPlayerAudience;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.StringTag;
-import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.protocol.game.ClientboundChatPacket;
-import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
-import net.minecraft.network.protocol.game.ClientboundCustomSoundPacket;
-import net.minecraft.network.protocol.game.ClientboundSetTitlesPacket;
-import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
 import net.minecraft.network.protocol.game.ServerboundClientInformationPacket;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.player.ChatVisiblity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -75,129 +55,38 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerPlayer.class)
-public abstract class ServerPlayerMixin extends Player implements Audience {
+public abstract class ServerPlayerMixin extends Player implements ForwardingAudience.Single, LocaleHolderBridge, RenderableAudience {
+  @Shadow @Final
+  public MinecraftServer server;
 
-  @Shadow private ChatVisiblity chatVisibility;
+  @Shadow
+  public ServerGamePacketListenerImpl connection;
+  private @MonotonicNonNull Audience adventure$backing;
+  private Locale adventure$locale;
+  private final Map<FabricServerAudienceProviderImpl, Audience> adventure$renderers = new MapMaker().weakKeys().makeMap();
 
-  @Shadow public ServerGamePacketListenerImpl connection;
+  public ServerPlayerMixin(final Level level, final BlockPos blockPos, final float f, final GameProfile gameProfile) {
+    super(level, blockPos, f, gameProfile);
+  }
 
-  public ServerPlayerMixin(final Level level, final BlockPos pos, final float yaw, final GameProfile gameProfile) {
-    super(level, pos, yaw, gameProfile);
+  @Inject(method = "<init>", at = @At("TAIL"))
+  private void applyBacking(final CallbackInfo ci) {
+    this.adventure$backing = FabricServerAudienceProvider.of(this.server).audience(this);
   }
 
   @Override
-  public void sendMessage(final Component text, final net.kyori.adventure.audience.MessageType type) {
-    final ChatType mcType;
-    final boolean shouldSend;
-    if(type == net.kyori.adventure.audience.MessageType.CHAT) {
-      mcType = ChatType.CHAT;
-      shouldSend = this.chatVisibility == ChatVisiblity.FULL;
-    } else {
-      mcType = ChatType.SYSTEM;
-      shouldSend = this.chatVisibility == ChatVisiblity.FULL || this.chatVisibility == ChatVisiblity.SYSTEM;
-    }
-
-    if(shouldSend) {
-      this.connection.send(new ClientboundChatPacket(FabricAudienceProvider.adapt(text), mcType, Util.NIL_UUID));
-    }
+  public @NonNull Audience audience() {
+    return this.adventure$backing;
   }
 
   @Override
-  public void sendActionBar(final @NonNull Component message) {
-    this.connection.send(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.ACTIONBAR, FabricAudienceProvider.adapt(message)));
+  public Audience renderUsing(final FabricServerAudienceProviderImpl controller) {
+    return this.adventure$renderers.computeIfAbsent(controller, ctrl -> new ServerPlayerAudience((ServerPlayer) (Object) this, ctrl));
   }
 
   @Override
-  public void showBossBar(final @NonNull BossBar bar) {
-    ServerBossBarListener.INSTANCE.subscribe((ServerPlayer) (Object) this, bar);
-  }
-
-  @Override
-  public void hideBossBar(final @NonNull BossBar bar) {
-    ServerBossBarListener.INSTANCE.unsubscribe((ServerPlayer) (Object) this, bar);
-  }
-
-  @Override
-  public void playSound(final @NonNull Sound sound) {
-    this.connection.send(new ClientboundCustomSoundPacket(FabricAudienceProvider.adapt(sound.name()),
-      GameEnums.SOUND_SOURCE.toMinecraft(sound.source()), this.position(), sound.volume(), sound.pitch()));
-  }
-
-  @Override
-  public void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
-    this.connection.send(new ClientboundCustomSoundPacket(FabricAudienceProvider.adapt(sound.name()),
-      GameEnums.SOUND_SOURCE.toMinecraft(sound.source()), new Vec3(x, y, z), sound.volume(), sound.pitch()));
-  }
-
-  @Override
-  public void stopSound(final @NonNull SoundStop stop) {
-    final /* @Nullable */ Key sound = stop.sound();
-    final Sound./* @Nullable */ Source src = stop.source();
-    final /* @Nullable */ SoundSource cat = src == null ? null : GameEnums.SOUND_SOURCE.toMinecraft(src);
-    this.connection.send(new ClientboundStopSoundPacket(sound == null ? null : FabricAudienceProvider.adapt(sound), cat));
-  }
-
-  private static final String BOOK_TITLE = "title";
-  private static final String BOOK_AUTHOR = "author";
-  private static final String BOOK_PAGES = "pages";
-  private static final String BOOK_RESOLVED = "resolved";
-
-  @Override
-  public void openBook(final @NonNull Book book) {
-    final ItemStack bookStack = new ItemStack(Items.WRITTEN_BOOK, 1);
-    final CompoundTag bookTag = bookStack.getOrCreateTag();
-    bookTag.putString(BOOK_TITLE, this.adventure$serialize(book.title()));
-    bookTag.putString(BOOK_AUTHOR, this.adventure$serialize(book.author()));
-    final ListTag pages = new ListTag();
-    for(final Component page : book.pages()) {
-      pages.add(StringTag.valueOf(this.adventure$serialize(page)));
-    }
-    bookTag.put(BOOK_PAGES, pages);
-    bookTag.putBoolean(BOOK_RESOLVED, true); // todo: any parseable texts?
-
-    final ItemStack previous = this.inventory.getSelected();
-    this.connection.send(new ClientboundContainerSetSlotPacket(-2, this.inventory.selected, bookStack));
-    this.openItemGui(bookStack, InteractionHand.MAIN_HAND);
-    this.connection.send(new ClientboundContainerSetSlotPacket(-2, this.inventory.selected, previous));
-  }
-
-  private String adventure$serialize(final @NonNull Component component) {
-    return GsonComponentSerializer.gson().serialize(component);
-  }
-
-  @Override
-  public void showTitle(final @NonNull Title title) {
-    if(title.subtitle() != TextComponent.empty()) {
-      this.connection.send(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.SUBTITLE, FabricAudienceProvider.adapt(title.subtitle())));
-    }
-
-    final /* @Nullable */ Title.Times times = title.times();
-    if(times != null) {
-      final int fadeIn = this.ticks(times.fadeIn());
-      final int fadeOut = this.ticks(times.fadeOut());
-      final int dwell = this.ticks(times.stay());
-      if(fadeIn != -1 || fadeOut != -1 || dwell != -1) {
-        this.connection.send(new ClientboundSetTitlesPacket(fadeIn, dwell, fadeOut));
-      }
-    }
-
-    if(title.title() != TextComponent.empty()) {
-      this.connection.send(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.TITLE, FabricAudienceProvider.adapt(title.title())));
-    }
-  }
-
-  private int ticks(final @NonNull Duration duration) {
-    return duration.getSeconds() == -1 ? -1 : (int) (duration.toMillis() / 50);
-  }
-
-  @Override
-  public void clearTitle() {
-    this.connection.send(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.CLEAR, null));
-  }
-
-  @Override
-  public void resetTitle() {
-    this.connection.send(new ClientboundSetTitlesPacket(ClientboundSetTitlesPacket.Type.RESET, null));
+  public Locale adventure$locale() {
+    return this.adventure$locale;
   }
 
   // Locale tracking
@@ -205,27 +94,10 @@ public abstract class ServerPlayerMixin extends Player implements Audience {
   @Inject(method = "updateOptions", at = @At("HEAD"))
   private void handleLocaleUpdate(final ServerboundClientInformationPacket information, final CallbackInfo ci) {
     final String language = ((ServerboundClientInformationPacketAccess) information).getLanguage();
-    final Channel channel = ((ConnectionAccess) this.connection.getConnection()).getChannel();
-    channel.attr(FriendlyByteBufBridge.CHANNEL_LOCALE).set(adventure$toLocale(language));
-  }
-
-  /**
-   * Take a locale string provided from a minecraft client and attempt to parse it as a locale.
-   * These are not strictly compliant with the iso standard, so we try to make things a bit more normalized.
-   *
-   * @param mcLocale The locale string, in the format provided by the Minecraft client
-   * @return A Locale object matching the provided locale string
-   */
-  private static @Nullable Locale adventure$toLocale(final @Nullable String mcLocale) {
-    if(mcLocale == null) return null;
-
-    final String[] parts = mcLocale.split("_", 3);
-    switch(parts.length) {
-      case 1: return parts[0].isEmpty() ? null : new Locale(parts[0]);
-      case 2: return new Locale(parts[0], parts[1]);
-      case 3: return new Locale(parts[0], parts[1], parts[2]);
-      case 0:
-      default: return null;
+    final /* @Nullable */ Locale locale = LocaleHolderBridge.toLocale(language);
+    if(!Objects.equals(this.adventure$locale, locale)) {
+      this.adventure$locale = locale;
+      PlayerLocales.CHANGED_EVENT.invoker().onLocaleChanged((ServerPlayer) (Object) this, locale);
     }
   }
 
@@ -233,12 +105,11 @@ public abstract class ServerPlayerMixin extends Player implements Audience {
 
   @Inject(method = "restoreFrom", at = @At("RETURN"))
   private void copyBossBars(final ServerPlayer old, final boolean alive, final CallbackInfo ci) {
-    ServerBossBarListener.INSTANCE.replacePlayer(old, (ServerPlayer) (Object) this);
+    FabricServerAudienceProviderImpl.forEachInstance(controller -> controller.bossBars().replacePlayer(old, (ServerPlayer) (Object) this));
   }
 
   @Inject(method = "disconnect", at = @At("RETURN"))
   private void removeBossBarsOnDisconnect(final CallbackInfo ci) {
-    ServerBossBarListener.INSTANCE.unsubscribeFromAll((ServerPlayer) (Object) this);
+    FabricServerAudienceProviderImpl.forEachInstance(controller -> controller.bossBars().unsubscribeFromAll((ServerPlayer) (Object) this));
   }
-
 }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/BossHealthOverlayMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/BossHealthOverlayMixin.java
@@ -24,11 +24,12 @@
 
 package net.kyori.adventure.platform.fabric.impl.mixin.client;
 
+import com.google.common.collect.MapMaker;
 import java.util.Map;
 import java.util.UUID;
 import net.kyori.adventure.platform.fabric.impl.client.BossHealthOverlayBridge;
 import net.kyori.adventure.platform.fabric.impl.client.ClientBossBarListener;
-import net.minecraft.client.Minecraft;
+import net.kyori.adventure.platform.fabric.impl.client.FabricClientAudienceProviderImpl;
 import net.minecraft.client.gui.components.BossHealthOverlay;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import org.spongepowered.asm.mixin.Final;
@@ -43,16 +44,11 @@ public class BossHealthOverlayMixin implements BossHealthOverlayBridge {
 
   @Shadow @Final private Map<UUID, LerpingBossEvent> events;
 
-  private ClientBossBarListener adventure$listener;
-
-  @Inject(method = "<init>", at = @At("RETURN"))
-  private void initListener(final Minecraft client, final CallbackInfo ci) {
-    this.adventure$listener = new ClientBossBarListener(this.events);
-  }
+  private Map<FabricClientAudienceProviderImpl, ClientBossBarListener> adventure$listener = new MapMaker().weakKeys().makeMap();
 
   @Override
-  public ClientBossBarListener adventure$listener() {
-    return this.adventure$listener;
+  public ClientBossBarListener adventure$listener(final FabricClientAudienceProviderImpl controller) {
+    return this.adventure$listener.computeIfAbsent(controller, ctrl -> new ClientBossBarListener(ctrl, this.events));
   }
 
   @Inject(method = "reset", at = @At("HEAD"))

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/LocalPlayerMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/LocalPlayerMixin.java
@@ -25,129 +25,45 @@
 package net.kyori.adventure.platform.fabric.impl.mixin.client;
 
 import com.mojang.authlib.GameProfile;
-import java.time.Duration;
+import java.util.Locale;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.audience.MessageType;
-import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.inventory.Book;
-import net.kyori.adventure.key.Key;
-import net.kyori.adventure.platform.fabric.FabricAudienceProvider;
-import net.kyori.adventure.platform.fabric.impl.GameEnums;
-import net.kyori.adventure.platform.fabric.impl.client.AdventureBookAccess;
-import net.kyori.adventure.platform.fabric.impl.client.BossHealthOverlayBridge;
+import net.kyori.adventure.audience.ForwardingAudience;
+import net.kyori.adventure.platform.fabric.FabricClientAudienceProvider;
+import net.kyori.adventure.platform.fabric.impl.LocaleHolderBridge;
 import net.kyori.adventure.sound.Sound;
-import net.kyori.adventure.sound.SoundStop;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.title.Title;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.inventory.BookViewScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.resources.sounds.SimpleSoundInstance;
-import net.minecraft.client.resources.sounds.SoundInstance;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.entity.player.ChatVisiblity;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LocalPlayer.class)
-public abstract class LocalPlayerMixin extends AbstractClientPlayer implements Audience {
+public abstract class LocalPlayerMixin extends AbstractClientPlayer implements ForwardingAudience.Single, LocaleHolderBridge {
+
+  @Shadow @Final protected Minecraft minecraft;
 
   // TODO: Do we want to enforce synchronization with the client thread?
-
   private LocalPlayerMixin(final ClientLevel level, final GameProfile profile) { // mixin will strip
     super(level, profile);
   }
 
-  @Shadow @Final protected Minecraft minecraft;
-
-  @Shadow public abstract void displayClientMessage(net.minecraft.network.chat.Component component, boolean bl);
+  private final Audience adventure$default = FabricClientAudienceProvider.of().audience();
 
   @Override
-  public void sendMessage(final @NonNull Component message, final @NonNull MessageType type) {
-    final ChatVisiblity visibility = this.minecraft.options.chatVisibility;
-    if(type == MessageType.CHAT) {
-      // Add to chat queue (following delay and such)
-      if(visibility == ChatVisiblity.FULL) {
-        this.minecraft.gui.getChat().enqueueMessage(FabricAudienceProvider.adapt(message));
-      }
-    } else {
-      // Add immediately as a system message
-      if(visibility == ChatVisiblity.FULL || visibility == ChatVisiblity.SYSTEM) {
-        this.minecraft.gui.getChat().addMessage(FabricAudienceProvider.adapt(message));
-      }
-    }
-  }
-
-  @Override
-  public void sendActionBar(final @NonNull Component message) {
-    this.displayClientMessage(FabricAudienceProvider.adapt(message), true);
-  }
-
-  @Override
-  public void showTitle(final @NonNull Title title) {
-    final /* @Nullable */ net.minecraft.network.chat.Component titleText = title.title() == TextComponent.empty() ? null : FabricAudienceProvider.adapt(title.title());
-    final /* @Nullable */ net.minecraft.network.chat.Component subtitleText = title.subtitle() == TextComponent.empty() ? null : FabricAudienceProvider
-            .adapt(title.subtitle());
-    final /* @Nullable */ Title.Times times = title.times();
-    this.minecraft.gui.setTitles(titleText, subtitleText,
-      this.adventure$ticks(times == null ? null : times.fadeIn()),
-      this.adventure$ticks(times == null ? null : times.stay()),
-      this.adventure$ticks(times == null ? null : times.fadeOut()));
-  }
-
-  private int adventure$ticks(final @Nullable Duration duration) {
-    return duration == null || duration.getSeconds() == -1 ? -1 : (int) (duration.toMillis() / 50);
-  }
-
-  @Override
-  public void clearTitle() {
-    this.minecraft.gui.setTitles(null, null, -1, -1, -1);
-  }
-
-  @Override
-  public void resetTitle() {
-    this.minecraft.gui.resetTitleTimes();
-  }
-
-  @Override
-  public void showBossBar(final @NonNull BossBar bar) {
-    BossHealthOverlayBridge.listener(this.minecraft.gui.getBossOverlay()).add(bar);
-  }
-
-  @Override
-  public void hideBossBar(final @NonNull BossBar bar) {
-    BossHealthOverlayBridge.listener(this.minecraft.gui.getBossOverlay()).remove(bar);
+  public @NonNull Audience audience() {
+    return this.adventure$default;
   }
 
   @Override
   public void playSound(final @NonNull Sound sound) {
-    this.playSound(sound, this.getX(), this.getY(), this.getZ());
+    this.audience().playSound(sound, this.getX(), this.getY(), this.getZ());
   }
 
   @Override
-  public void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
-    this.minecraft.getSoundManager().play(new SimpleSoundInstance(FabricAudienceProvider.adapt(sound.name()), GameEnums.SOUND_SOURCE.toMinecraft(sound.source()),
-      sound.volume(), sound.pitch(), false, 0, SoundInstance.Attenuation.LINEAR, x, y, z, false));
-  }
-
-  @Override
-  public void stopSound(final @NonNull SoundStop stop) {
-    final /* @Nullable */ Key sound = stop.sound();
-    final /* @Nullable */ ResourceLocation soundIdent = sound == null ? null : FabricAudienceProvider.adapt(sound);
-    final Sound./* @Nullable */ Source source = stop.source();
-    final /* @Nullable */ SoundSource category = source == null ? null : GameEnums.SOUND_SOURCE.toMinecraft(source);
-    this.minecraft.getSoundManager().stop(soundIdent, category);
-  }
-
-  @Override
-  public void openBook(final @NonNull Book book) {
-    this.minecraft.setScreen(new BookViewScreen(new AdventureBookAccess(book)));
+  public Locale adventure$locale() {
+    return ((LocaleHolderBridge) this.minecraft.options).adventure$locale();
   }
 }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/OptionsMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/client/OptionsMixin.java
@@ -22,30 +22,31 @@
  * SOFTWARE.
  */
 
-package net.kyori.adventure.platform.fabric.impl;
+package net.kyori.adventure.platform.fabric.impl.mixin.client;
 
-import net.kyori.adventure.platform.fabric.impl.accessor.ComponentSerializerAccess;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.minecraft.network.chat.MutableComponent;
+import java.util.Locale;
+import java.util.Objects;
+import net.kyori.adventure.platform.fabric.impl.LocaleHolderBridge;
+import net.minecraft.client.Options;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
-public final class NonWrappingComponentSerializer implements ComponentSerializer<Component, Component, net.minecraft.network.chat.Component> {
-  public static final NonWrappingComponentSerializer INSTANCE = new NonWrappingComponentSerializer();
+@Mixin(Options.class)
+public class OptionsMixin implements LocaleHolderBridge {
+  @Shadow
+  public String languageCode;
 
-  private NonWrappingComponentSerializer() {
-  }
+  private String adventure$cachedLanguage;
+  private Locale adventure$cachedLocale;
 
   @Override
-  public Component deserialize(final net.minecraft.network.chat.Component input) {
-    if(input instanceof WrappedComponent) {
-      return ((WrappedComponent) input).wrapped();
+  public Locale adventure$locale() {
+    final String language = this.languageCode;
+    if(Objects.equals(this.adventure$cachedLanguage, language)) {
+      return this.adventure$cachedLocale;
+    } else {
+      this.adventure$cachedLanguage = language;
+      return this.adventure$cachedLocale = LocaleHolderBridge.toLocale(language);
     }
-
-    return ComponentSerializerAccess.getGSON().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(input), Component.class);
-  }
-
-  @Override
-  public MutableComponent serialize(final Component component) {
-    return net.minecraft.network.chat.Component.Serializer.fromJson(ComponentSerializerAccess.getGSON().toJsonTree(component));
   }
 }

--- a/src/mixin/resources/adventure-platform-fabric.mixins.json
+++ b/src/mixin/resources/adventure-platform-fabric.mixins.json
@@ -15,7 +15,8 @@
   ],
   "client": [
     "client.BossHealthOverlayMixin",
-    "client.LocalPlayerMixin"
+    "client.LocalPlayerMixin",
+    "client.OptionsMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/mixin/resources/adventure-platform-fabric.mixins.json
+++ b/src/mixin/resources/adventure-platform-fabric.mixins.json
@@ -5,7 +5,9 @@
   "mixins": [
     "CommandSourceStackMixin",
     "ComponentSerializerMixin",
+    "FriendlyByteBufMixin",
     "MinecraftServerMixin",
+    "PacketEncoderMixin",
     "PlayerListMixin",
     "RconConsoleSourceMixin",
     "ServerBossEventMixin",

--- a/src/testmod/java/net/kyori/adventure/platform/test/fabric/AdventureTester.java
+++ b/src/testmod/java/net/kyori/adventure/platform/test/fabric/AdventureTester.java
@@ -53,8 +53,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.platform.fabric.KeyArgumentType;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
@@ -69,28 +67,33 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static java.util.Objects.requireNonNull;
+import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.platform.fabric.ComponentArgumentType.component;
 import static net.kyori.adventure.platform.fabric.KeyArgumentType.key;
-import static net.kyori.adventure.text.TextComponent.newline;
+import static net.kyori.adventure.sound.Sound.sound;
+import static net.kyori.adventure.text.Component.newline;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.TextColor.color;
 import static net.minecraft.commands.Commands.argument;
 import static net.minecraft.commands.Commands.literal;
 import static net.minecraft.commands.arguments.EntityArgument.getPlayers;
 import static net.minecraft.commands.arguments.EntityArgument.players;
 
 public class AdventureTester implements ModInitializer {
-  private static final Key FONT_MEOW = Key.of("adventure", "meow");
-  private static final Key FONT_IOSEVKA = Key.of("adventure", "iosevka");
+  private static final Key FONT_MEOW = key("adventure", "meow");
+  private static final Key FONT_IOSEVKA = key("adventure", "iosevka");
 
   private static final List<TextColor> LINE_COLOURS = IntStream.of(0x9400D3, 0x4B0082, 0x0000FF, 0x00FF00, 0xFFFF00, 0xFF7F00, 0xFF0000,
                                                                   0x55CDFC, 0xF7A8B8, 0xFFFFFF, 0xF7A8B8, 0x55CDFC)
-                                                                  .mapToObj(TextColor::of).collect(Collectors.toList());
-  private static final Component LINE = TextComponent.of(Strings.repeat("█", 10));
+                                                                  .mapToObj(TextColor::color).collect(Collectors.toList());
+  private static final Component LINE = text(Strings.repeat("█", 10));
 
   private static final String ARG_TEXT = "text";
   private static final String ARG_SECONDS = "seconds";
   private static final String ARG_TARGETS = "targets";
   private static final String ARG_SOUND = "sound";
-  private static final TextColor COLOR_RESPONSE = TextColor.of(0x22EE99);
+  private static final TextColor COLOR_RESPONSE = color(0x22EE99);
 
   private final Map<UUID, BossBar> greetingBars = new HashMap<>();
   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
@@ -117,8 +120,8 @@ public class AdventureTester implements ModInitializer {
       dispatcher.register(literal("adventure")
         .then(literal("about").executes(ctx -> {
           final Audience audience = this.adventure().audience(ctx.getSource());
-          audience.sendMessage(TranslatableComponent.of("adventure.test.welcome", COLOR_RESPONSE, this.adventure().toAdventure(ctx.getSource().getDisplayName())));
-          audience.sendMessage(TranslatableComponent.of("adventure.test.description", TextColor.of(0xc022cc)));
+          audience.sendMessage(translatable("adventure.test.welcome", COLOR_RESPONSE, this.adventure().toAdventure(ctx.getSource().getDisplayName())));
+          audience.sendMessage(translatable("adventure.test.description", color(0xc022cc)));
           return 1;
         }))
         .then(literal("echo").then(argument(ARG_TEXT, component()).executes(ctx -> {
@@ -129,12 +132,12 @@ public class AdventureTester implements ModInitializer {
         })))
         .then(literal("countdown").then(argument(ARG_SECONDS, integer()).executes(ctx -> { // multiple boss bars!
           final Audience audience = this.adventure().audience(ctx.getSource());
-          this.beginCountdown(TextComponent.of("Countdown"), getInteger(ctx, ARG_SECONDS), audience, BossBar.Color.RED, complete -> {
-            complete.sendActionBar(TextComponent.of("Countdown complete!", COLOR_RESPONSE));
+          this.beginCountdown(text("Countdown"), getInteger(ctx, ARG_SECONDS), audience, BossBar.Color.RED, complete -> {
+            complete.sendActionBar(text("Countdown complete!", COLOR_RESPONSE));
           });
-          this.beginCountdown(TextComponent.of("Faster Countdown"), getInteger(ctx, ARG_SECONDS) / 2, audience, BossBar.Color.PURPLE, complete -> {
-            complete.sendActionBar(TextComponent.builder("Faster Countdown complete! ", COLOR_RESPONSE)
-              .append(TextComponent.of('\uE042', Style.builder().font(FONT_MEOW).build())).build()); // private use kitten in font
+          this.beginCountdown(text("Faster Countdown"), getInteger(ctx, ARG_SECONDS) / 2, audience, BossBar.Color.PURPLE, complete -> {
+            complete.sendActionBar(text().content("Faster Countdown complete! ").color(COLOR_RESPONSE)
+              .append(text('\uE042', Style.builder().font(FONT_MEOW).build()))); // private use kitten in font
           });
           return 1;
         })))
@@ -145,8 +148,9 @@ public class AdventureTester implements ModInitializer {
         final Audience destination = this.adventure().audience(targets);
 
         destination.sendMessage(message);
-        source.sendMessage(TextComponent.make("You have sent \"", b -> {
-          b.append(message).append("\" to ").append(this.listPlayers(targets));
+        source.sendMessage(text(b -> {
+          b.content("You have sent \"");
+          b.append(message).append(text("\" to ")).append(this.listPlayers(targets));
           b.color(COLOR_RESPONSE);
         }));
         return 1;
@@ -154,17 +158,17 @@ public class AdventureTester implements ModInitializer {
       .then(literal("sound").then(argument(ARG_SOUND, key()).suggests(SuggestionProviders.AVAILABLE_SOUNDS).executes(ctx -> {
         final Audience viewer = this.adventure().audience(ctx.getSource());
         final Key sound = KeyArgumentType.key(ctx, ARG_SOUND);
-        viewer.sendMessage(TextComponent.make("Playing sound ", b -> b.append(represent(sound)).color(COLOR_RESPONSE)));
-        viewer.playSound(Sound.of(sound, Sound.Source.MASTER, 1f, 1f));
+        viewer.sendMessage(text(b -> b.content("Playing sound ").append(represent(sound)).color(COLOR_RESPONSE)));
+        viewer.playSound(sound(sound, Sound.Source.MASTER, 1f, 1f));
         return 1;
       })))
       .then(literal("book").executes(ctx -> {
         final Audience viewer = this.adventure().audience(ctx.getSource());
         viewer.openBook(Book.builder()
-        .title(TextComponent.of("My book", NamedTextColor.RED))
-        .author(TextComponent.of("The adventure team", COLOR_RESPONSE))
-        .addPage(TextComponent.of("Welcome to our rules page"))
-        .addPage(TextComponent.of("Let's do a thing!"))
+        .title(text("My book", NamedTextColor.RED))
+        .author(text("The adventure team", COLOR_RESPONSE))
+        .addPage(text("Welcome to our rules page"))
+        .addPage(text("Let's do a thing!"))
         .build());
         return 1;
       }))
@@ -178,7 +182,7 @@ public class AdventureTester implements ModInitializer {
       .then(literal("baron").executes(ctx -> {
         final ServerPlayer player = ctx.getSource().getPlayerOrException();
         final BossBar greeting = this.greetingBars.computeIfAbsent(player.getUUID(), id -> {
-          return BossBar.of(TranslatableComponent.of("adventure.test.greeting", NamedTextColor.GOLD, this.adventure().toAdventure(player.getDisplayName())),
+          return BossBar.bossBar(translatable("adventure.test.greeting", NamedTextColor.GOLD, this.adventure().toAdventure(player.getDisplayName())),
           1, BossBar.Color.YELLOW, BossBar.Overlay.PROGRESS);
         });
 
@@ -195,10 +199,10 @@ public class AdventureTester implements ModInitializer {
     });
   }
 
-  private static final Component COLON = TextComponent.of(":", NamedTextColor.GRAY);
-  private static final TextColor COLOR_PATH = TextColor.of(0x18A4C2);
-  private static final TextColor COLOR_NAMESPACE = TextColor.of(0x0D6679);
-  private static final TextColor COLOR_NAMESPACE_VANILLA = TextColor.of(0x4A656B);
+  private static final Component COLON = text(":", NamedTextColor.GRAY);
+  private static final TextColor COLOR_PATH = color(0x18A4C2);
+  private static final TextColor COLOR_NAMESPACE = color(0x0D6679);
+  private static final TextColor COLOR_NAMESPACE_VANILLA = color(0x4A656B);
 
   private static Component represent(final @NonNull Key ident) {
     final TextColor namespaceColor;
@@ -208,15 +212,17 @@ public class AdventureTester implements ModInitializer {
       namespaceColor = COLOR_NAMESPACE;
     }
 
-    return TextComponent.builder(ident.namespace(), namespaceColor)
+    return text()
+      .content(ident.namespace())
+      .color(namespaceColor)
       .append(COLON)
-      .append(TextComponent.of(ident.value(), COLOR_PATH))
+      .append(text(ident.value(), COLOR_PATH))
       .build();
 
   }
 
   private Component listPlayers(final Collection<? extends ServerPlayer> players) {
-    final HoverEvent<Component> hover = HoverEvent.showText(TextComponent.make(b -> {
+    final HoverEvent<Component> hover = HoverEvent.showText(Component.text(b -> {
       boolean first = true;
       for(final ServerPlayer player : players) {
         if(!first) {
@@ -226,7 +232,7 @@ public class AdventureTester implements ModInitializer {
         b.append(this.adventure().toAdventure(player.getDisplayName()));
       }
     }));
-    return TextComponent.builder(players.size() + " players")
+    return text().content(players.size() + " players")
       .decoration(TextDecoration.UNDERLINED, true)
       .hoverEvent(hover).build();
   }
@@ -240,7 +246,7 @@ public class AdventureTester implements ModInitializer {
    * @param completionAction callback to execute when countdown is complete
    */
   private void beginCountdown(final Component title, final int timeSeconds, final Audience targets, final BossBar.Color color, final Consumer<Audience> completionAction) {
-    final BossBar bar = BossBar.of(title.style(builder -> builder.colorIfAbsent(textColor(color)).font(FONT_IOSEVKA)), 1, color, BossBar.Overlay.PROGRESS, Collections.singleton(BossBar.Flag.PLAY_BOSS_MUSIC));
+    final BossBar bar = BossBar.bossBar(title.style(builder -> builder.colorIfAbsent(textColor(color)).font(FONT_IOSEVKA)), 1, color, BossBar.Overlay.PROGRESS, Collections.singleton(BossBar.Flag.PLAY_BOSS_MUSIC));
 
     final int timeMs = timeSeconds * 1000; // total time ms
     final long[] times = new long[] {timeMs, System.currentTimeMillis()}; // remaining time in ms, last update time

--- a/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages.properties
+++ b/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages.properties
@@ -1,0 +1,2 @@
+adventure.test.welcome=Welcome to the server, {0}
+adventure.test.description=A test mod for Adventure

--- a/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages.properties
+++ b/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages.properties
@@ -1,2 +1,3 @@
 adventure.test.welcome=Welcome to the server, {0}
 adventure.test.description=A test mod for Adventure
+adventure.test.greeting=Good morning "{0}"!

--- a/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages_de.properties
+++ b/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages_de.properties
@@ -1,0 +1,2 @@
+adventure.test.welcome=Wilkommen im Server, {0}
+adventure.test.description=Ein Testmod für Adventure

--- a/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages_de.properties
+++ b/src/testmod/resources/net/kyori/adventure/platform/test/fabric/messages_de.properties
@@ -1,2 +1,3 @@
 adventure.test.welcome=Wilkommen im Server, {0}
-adventure.test.description=Ein Testmod f�r Adventure
+adventure.test.description=Ein Testmod für Adventure
+adventure.test.greeting=Guten morgen „{0}‟!


### PR DESCRIPTION
This is a restructuring of the platform implementation to allow rendering components.

This design should allow rendering any converted components in any packet that uses the standard `FriendlyByteBuf` write methods, or any components created directly on the client.