### PR TITLE
Include key as modApi

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+  modApi(include(adventure("key", versionAdventure))!!)
   modApi(include(adventure("api", versionAdventure))!!)
   modApi(include(adventure("text-serializer-plain", versionAdventure))!!)
   modApi(include(adventure("text-feature-pagination", versionAdventurePagination))!!)


### PR DESCRIPTION
I was getting `java.lang.ClassNotFoundException: net.kyori.adventure.key.Key` when testing, and this seemed to fix it