### PR TITLE
Workaround to allow `open_file` click events to work with client audiences

### DIFF
--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/StyleSerializerMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/StyleSerializerMixin.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl.mixin;
+
+import net.kyori.adventure.platform.fabric.impl.NonWrappingComponentSerializer;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Style;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Style.Serializer.class)
+abstract class StyleSerializerMixin {
+  @Redirect(method = "getClickEvent", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/chat/ClickEvent$Action;isAllowedFromServer()Z"))
+  private static boolean adventure$redirectIsAllowedFromServer(final ClickEvent.@NonNull Action action) {
+    if(NonWrappingComponentSerializer.INSTANCE.bypassIsAllowedFromServer()) {
+      return true;
+    }
+    return action.isAllowedFromServer();
+  }
+}

--- a/src/mixin/resources/adventure-platform-fabric.mixins.json
+++ b/src/mixin/resources/adventure-platform-fabric.mixins.json
@@ -14,7 +14,8 @@
     "PlayerMixin",
     "RconConsoleSourceMixin",
     "ServerBossEventMixin",
-    "ServerPlayerMixin"
+    "ServerPlayerMixin",
+    "StyleSerializerMixin"
   ],
   "client": [
     "client.BossHealthOverlayMixin",


### PR DESCRIPTION
This change allows `open_file` click events to be persisted when converting `Component`s from Adventure to Vanilla using the `NonWrappingComponentSerializer`. I haven't tested it, but I assume they will be lost when converting from Vanilla to Adventure.