### PR TITLE
Make CommandSyntaxException a ComponentMessageThrowable

### DIFF
--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.platform.fabric;
 
 import com.mojang.authlib.GameProfile;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.identity.Identified;
@@ -38,6 +39,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.util.ComponentMessageThrowable;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -121,6 +123,17 @@ public interface FabricAudiences {
    */
   static Sound.@NotNull Emitter asEmitter(final @NotNull Entity entity) {
     return (Sound.Emitter) entity;
+  }
+
+  /**
+   * Expose a Brigadier CommandSyntaxException's message using the adventure-provided interface for rich-message exceptions.
+   *
+   * @param ex the exception to cast
+   * @return a converted command exception
+   * @since 5.3.0
+   */
+  static @NotNull ComponentMessageThrowable asComponentThrowable(final @NotNull CommandSyntaxException ex) {
+    return (ComponentMessageThrowable) ex;
   }
 
   /**

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventurePrelaunch.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/AdventurePrelaunch.java
@@ -55,6 +55,7 @@ public class AdventurePrelaunch implements PreLaunchEntrypoint {
   public void onPreLaunch() {
     try {
       AdventurePrelaunch.hackilyLoadForMixin("com.mojang.authlib.UserAuthentication");
+      AdventurePrelaunch.hackilyLoadForMixin("com.mojang.brigadier.Message");
     } catch (final ClassNotFoundException | InvocationTargetException | IllegalAccessException e) {
       throw new RuntimeException("please fix fabric loader to enable transforming libraries normally", e);
     }

--- a/src/main/resources/fabric.mod.yaml
+++ b/src/main/resources/fabric.mod.yaml
@@ -21,7 +21,7 @@ custom:
   modmenu:api: true
 
 depends:
-  fabricloader: ">=0.4.0"
+  fabricloader: ">=0.14.0"
   fabric-api-base: "*"
 suggests:
   colonel: ">=0.1"

--- a/src/main/resources/fabric.mod.yaml
+++ b/src/main/resources/fabric.mod.yaml
@@ -21,7 +21,7 @@ custom:
   modmenu:api: true
 
 depends:
-  fabricloader: ">=0.14.0"
+  fabricloader: ">=0.4.0"
   fabric-api-base: "*"
 suggests:
   colonel: ">=0.1"

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
@@ -35,13 +35,13 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(value = CommandSyntaxException.class, remap = false)
 abstract class CommandSyntaxExceptionMixin implements ComponentMessageThrowable {
-  @Shadow
-  @SuppressWarnings("checkstyle:MethodName")
-  public abstract Message getRawMessage();
+  // @formatter:off
+  @Shadow public abstract Message shadow$getRawMessage();
+  // @formatter:on
 
   @Override
   public @NotNull Component componentMessage() {
-    final net.minecraft.network.chat.Component minecraft = ComponentUtils.fromMessage(this.getRawMessage());
+    final net.minecraft.network.chat.Component minecraft = ComponentUtils.fromMessage(this.shadow$getRawMessage());
 
     return FabricAudiences.nonWrappingSerializer().deserialize(minecraft);
   }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
@@ -36,11 +36,13 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(value = CommandSyntaxException.class, remap = false)
 abstract class CommandSyntaxExceptionMixin implements ComponentMessageThrowable {
   @Shadow
+  @SuppressWarnings("checkstyle:MethodName")
   public abstract Message getRawMessage();
 
   @Override
   public @NotNull Component componentMessage() {
     final net.minecraft.network.chat.Component minecraft = ComponentUtils.fromMessage(this.getRawMessage());
+
     return FabricAudiences.nonWrappingSerializer().deserialize(minecraft);
   }
 }

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
@@ -1,0 +1,23 @@
+package net.kyori.adventure.platform.fabric.impl.mixin;
+
+import com.mojang.brigadier.Message;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.kyori.adventure.platform.fabric.FabricAudiences;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.util.ComponentMessageThrowable;
+import net.minecraft.network.chat.ComponentUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = CommandSyntaxException.class, remap = false)
+abstract class CommandSyntaxExceptionMixin implements ComponentMessageThrowable {
+  @Shadow
+  public abstract Message getRawMessage();
+
+  @Override
+  public @NonNull Component componentMessage() {
+    final net.minecraft.network.chat.Component minecraft = ComponentUtils.fromMessage(this.getRawMessage());
+    return FabricAudiences.nonWrappingSerializer().deserialize(minecraft);
+  }
+}

--- a/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
+++ b/src/mixin/java/net/kyori/adventure/platform/fabric/impl/mixin/CommandSyntaxExceptionMixin.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.platform.fabric.impl.mixin;
 
 import com.mojang.brigadier.Message;
@@ -6,7 +29,7 @@ import net.kyori.adventure.platform.fabric.FabricAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.ComponentMessageThrowable;
 import net.minecraft.network.chat.ComponentUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
@@ -16,7 +39,7 @@ abstract class CommandSyntaxExceptionMixin implements ComponentMessageThrowable 
   public abstract Message getRawMessage();
 
   @Override
-  public @NonNull Component componentMessage() {
+  public @NotNull Component componentMessage() {
     final net.minecraft.network.chat.Component minecraft = ComponentUtils.fromMessage(this.getRawMessage());
     return FabricAudiences.nonWrappingSerializer().deserialize(minecraft);
   }

--- a/src/mixin/resources/adventure-platform-fabric.mixins.json
+++ b/src/mixin/resources/adventure-platform-fabric.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "ClientboundStatusResponsePacketMixin",
     "CommandSourceStackMixin",
+    "CommandSyntaxExceptionMixin",
     "ComponentSerializerMixin",
     "EntityMixin",
     "FriendlyByteBufMixin",


### PR DESCRIPTION
I explored using a Mixin plugin to only load the Mixin in loader 0.14+, but couldn't think of a good way to detect the loader version, so for now this just requires loader 0.14+, which isn't ideal.

I also tested adding CommandSyntaxException to hackilyLoadForMixin, which caused loader constraint violation errors on loader pre-0.14.