### PR TITLE
Mark mod as library for newer modmenu

### DIFF
--- a/src/main/resource-templates/fabric.mod.yaml
+++ b/src/main/resource-templates/fabric.mod.yaml
@@ -23,8 +23,8 @@ mixins:
   - "adventure-platform-fabric.mixins.json"
   - "adventure-platform-fabric.client.mixins.json"
 custom:
+  modmenu:api: true
   modmenu:
-    api: true
     badges: [ "library" ]
   loom:injected_interfaces:
     net/minecraft/class_2168: [ net/kyori/adventure/platform/fabric/AdventureCommandSourceStack ] # net/minecraft/commands/CommandSourceStack

--- a/src/main/resource-templates/fabric.mod.yaml
+++ b/src/main/resource-templates/fabric.mod.yaml
@@ -23,7 +23,9 @@ mixins:
   - "adventure-platform-fabric.mixins.json"
   - "adventure-platform-fabric.client.mixins.json"
 custom:
-  modmenu:api: true
+  modmenu:
+    api: true
+    badges: [ "library" ]
   loom:injected_interfaces:
     net/minecraft/class_2168: [ net/kyori/adventure/platform/fabric/AdventureCommandSourceStack ] # net/minecraft/commands/CommandSourceStack
     net/minecraft/class_1297: [ net/kyori/adventure/sound/Sound<%= '$' %>Emitter, net/kyori/adventure/platform/fabric/EntityHoverEventSource ] # net/minecraft/world/entity/Entity


### PR DESCRIPTION
The old `api: true` syntax is deprecated in ModMenu 3+, the badges syntax is used instead.