### PR TITLE
feat: Hook into fabric-permissions-api to provide the PermissionChecker pointer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
       releasesOnly()
     }
   }
+  sonatype.ossSnapshots()
   sonatype.s01Snapshots()
 }
 
@@ -138,6 +139,11 @@ val testmod = sourceSets.register("testmod") {
   resources.srcDirs("src/testmodMixin/resources")
 }
 
+val permissionsApiCompat = sourceSets.register("permissionsApiCompat") {
+  compileClasspath += sourceSets.named("client").get().compileClasspath
+  runtimeClasspath += sourceSets.named("client").get().runtimeClasspath
+}
+
 configurations.named("clientAnnotationProcessor") {
   extendsFrom(configurations.annotationProcessor.get())
 }
@@ -167,6 +173,7 @@ loom {
     register("adventure-platform-fabric") {
       sourceSet(sourceSets.main.get())
       sourceSet(sourceSets.named("client").get())
+      sourceSet(permissionsApiCompat.get())
     }
     register("adventure-platform-fabric-testmod") {
       sourceSet(testmod.get())
@@ -180,11 +187,15 @@ loom {
   }
 
   createRemapConfigurations(testmod.get())
+  createRemapConfigurations(permissionsApiCompat.get())
 }
 
 
 dependencies {
   "testmodImplementation"(sourceSets.named("client").map { it.output })
+  "permissionsApiCompatImplementation"(sourceSets.named("client").map { it.output })
+  "testmodRuntimeOnly"(permissionsApiCompat.map { it.output })
+  "modPermissionsApiCompatImplementation"(libs.fabric.permissionsApi)
 
   // Testmod-specific dependencies
   "modTestmodImplementation"(libs.fabric.api)
@@ -221,6 +232,14 @@ tasks {
       "https://jd.advntr.dev/key/${libs.versions.adventure.get()}",
       "https://jd.advntr.dev/platform/api/${libs.versions.adventurePlatform.get()}",
     )
+  }
+
+  jar {
+    from(permissionsApiCompat.map { it.output })
+  }
+
+  sourcesJar {
+    from(permissionsApiCompat.map { it.allSource })
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ examination-api = { module = "net.kyori:examination-api", version.ref = "examina
 examination-string = { module = "net.kyori:examination-string", version.ref = "examination" }
 fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabricLoader"}
 fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabricApi" }
+fabric-permissionsApi = { module = "me.lucko:fabric-permissions-api", version = "0.2-SNAPSHOT" }
 jetbrainsAnnotations = "org.jetbrains:annotations:24.0.1"
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 

--- a/src/main/resource-templates/fabric.mod.yaml
+++ b/src/main/resource-templates/fabric.mod.yaml
@@ -13,6 +13,7 @@ icon: assets/adventure-platform-fabric/logo.png
 entrypoints:
   main:
     - "net.kyori.adventure.platform.fabric.impl.AdventureCommon"
+    - "net.kyori.adventure.platform.fabric.impl.compat.permissions.PermissionsApiIntegration"
   client:
     - "net.kyori.adventure.platform.fabric.impl.client.AdventureClient"
   adventure-internal:sidedproxy/client:

--- a/src/permissionsApiCompat/java/net/kyori/adventure/platform/fabric/impl/compat/permissions/PermissionsApiIntegration.java
+++ b/src/permissionsApiCompat/java/net/kyori/adventure/platform/fabric/impl/compat/permissions/PermissionsApiIntegration.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure-platform-fabric, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.fabric.impl.compat.permissions;
+
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.kyori.adventure.permission.PermissionChecker;
+import net.kyori.adventure.platform.fabric.CollectPointersCallback;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import net.kyori.adventure.util.TriState;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.world.entity.Entity;
+
+public class PermissionsApiIntegration implements ModInitializer {
+  private static final ComponentLogger LOGGER = ComponentLogger.logger();
+  private static final String PERMISSIONS_API_MOD_NAME = "fabric-permissions-api-v0";
+
+  @Override
+  public void onInitialize() {
+    if (FabricLoader.getInstance().isModLoaded(PERMISSIONS_API_MOD_NAME)) {
+      this.registerPermissionHook();
+      LOGGER.debug("Registered fabric-permissions-api hook");
+    } else {
+      LOGGER.debug("fabric-permissions-api not detected, the PermissionChecker pointer will not be present");
+    }
+  }
+
+  private void registerPermissionHook() {
+    CollectPointersCallback.EVENT.register((pointered, consumer) -> {
+      if (pointered instanceof Entity e) {
+        consumer.withStatic(
+          PermissionChecker.POINTER,
+          perm -> adaptTristate(Permissions.getPermissionValue(e, perm))
+        );
+      } else if (pointered instanceof SharedSuggestionProvider sourceStack) {
+        consumer.withStatic(
+          PermissionChecker.POINTER,
+          perm -> adaptTristate(Permissions.getPermissionValue(sourceStack, perm))
+        );
+      }
+    });
+  }
+
+  private static TriState adaptTristate(final net.fabricmc.fabric.api.util.TriState fabricState) {
+    return switch (fabricState) {
+      case FALSE -> TriState.FALSE;
+      case DEFAULT -> TriState.NOT_SET;
+      case TRUE -> TriState.TRUE;
+    };
+  }
+}

--- a/src/permissionsApiCompat/java/net/kyori/adventure/platform/fabric/impl/compat/permissions/package-info.java
+++ b/src/permissionsApiCompat/java/net/kyori/adventure/platform/fabric/impl/compat/permissions/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides hooks to expose permissions API functionality to Adventure API users.
+ */
+package net.kyori.adventure.platform.fabric.impl.compat.permissions;


### PR DESCRIPTION
Based on #86, using the newly added API to provide the `PermissionChecker` pointer.

Closes #82 