### PR TITLE
Use server's registry access in server audience component conversions

### DIFF
--- a/src/client/java/net/kyori/adventure/platform/fabric/impl/client/ClientProxy.java
+++ b/src/client/java/net/kyori/adventure/platform/fabric/impl/client/ClientProxy.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of adventure-platform-fabric, licensed under the MIT License.
  *
- * Copyright (c) 2020-2022 KyoriPowered
+ * Copyright (c) 2020-2024 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 package net.kyori.adventure.platform.fabric.impl.client;
 
 import java.util.function.Function;
+import net.kyori.adventure.platform.fabric.impl.NonWrappingComponentSerializer;
 import net.kyori.adventure.platform.fabric.impl.SidedProxy;
 import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
 import net.kyori.adventure.pointer.Pointered;
@@ -47,7 +48,8 @@ public class ClientProxy implements SidedProxy {
   public @NotNull WrappedComponent createWrappedComponent(
     final @NotNull Component wrapped,
     final @Nullable Function<Pointered, ?> partition,
-    final @Nullable ComponentRenderer<Pointered> renderer
+    final @Nullable ComponentRenderer<Pointered> renderer,
+    final @Nullable NonWrappingComponentSerializer nonWrappingSerializer
   ) {
     return new ClientWrappedComponent(wrapped, partition, renderer);
   }

--- a/src/client/java/net/kyori/adventure/platform/fabric/impl/client/ClientWrappedComponent.java
+++ b/src/client/java/net/kyori/adventure/platform/fabric/impl/client/ClientWrappedComponent.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of adventure-platform-fabric, licensed under the MIT License.
  *
- * Copyright (c) 2020-2023 KyoriPowered
+ * Copyright (c) 2020-2024 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 public final class ClientWrappedComponent extends WrappedComponent {
   public ClientWrappedComponent(final Component wrapped, final @Nullable Function<Pointered, ?> partition, final @Nullable ComponentRenderer<Pointered> renderer) {
-    super(wrapped, partition, renderer);
+    super(wrapped, partition, renderer, null);
   }
 
   @Override

--- a/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/FabricAudiences.java
@@ -85,7 +85,7 @@ public interface FabricAudiences {
       partition = null;
       renderer = null;
     }
-    return AdventureCommon.SIDE_PROXY.createWrappedComponent(modified, partition, renderer);
+    return AdventureCommon.SIDE_PROXY.createWrappedComponent(modified, partition, renderer, null);
   }
 
   /**

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/NonWrappingComponentSerializer.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/NonWrappingComponentSerializer.java
@@ -47,7 +47,7 @@ public final class NonWrappingComponentSerializer implements ComponentSerializer
     this(Suppliers.ofInstance(RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY)));
   }
 
-  private NonWrappingComponentSerializer(final @NotNull Supplier<HolderLookup.@NotNull Provider> provider) {
+  public NonWrappingComponentSerializer(final @NotNull Supplier<HolderLookup.@NotNull Provider> provider) {
     this.holderProvider = provider;
   }
 

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/SidedProxy.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/SidedProxy.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of adventure-platform-fabric, licensed under the MIT License.
  *
- * Copyright (c) 2020-2022 KyoriPowered
+ * Copyright (c) 2020-2024 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@ public interface SidedProxy {
   @NotNull WrappedComponent createWrappedComponent(
     final @NotNull Component wrapped,
     final @Nullable Function<Pointered, ?> partition,
-    final @Nullable ComponentRenderer<Pointered> renderer
+    final @Nullable ComponentRenderer<Pointered> renderer,
+    final @Nullable NonWrappingComponentSerializer nonWrappingSerializer
   );
 }

--- a/src/main/java/net/kyori/adventure/platform/fabric/impl/server/DedicatedServerProxy.java
+++ b/src/main/java/net/kyori/adventure/platform/fabric/impl/server/DedicatedServerProxy.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of adventure-platform-fabric, licensed under the MIT License.
  *
- * Copyright (c) 2020-2022 KyoriPowered
+ * Copyright (c) 2020-2024 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 package net.kyori.adventure.platform.fabric.impl.server;
 
 import java.util.function.Function;
+import net.kyori.adventure.platform.fabric.impl.NonWrappingComponentSerializer;
 import net.kyori.adventure.platform.fabric.impl.SidedProxy;
 import net.kyori.adventure.platform.fabric.impl.WrappedComponent;
 import net.kyori.adventure.pointer.Pointered;
@@ -43,8 +44,9 @@ public class DedicatedServerProxy implements SidedProxy {
   public @NotNull WrappedComponent createWrappedComponent(
     final @NotNull Component wrapped,
     final @Nullable Function<Pointered, ?> partition,
-    final @Nullable ComponentRenderer<Pointered> renderer
+    final @Nullable ComponentRenderer<Pointered> renderer,
+    final @Nullable NonWrappingComponentSerializer nonWrappingSerializer
   ) {
-    return new WrappedComponent(wrapped, partition, renderer);
+    return new WrappedComponent(wrapped, partition, renderer, nonWrappingSerializer);
   }
 }

--- a/src/test/java/net/kyori/adventure/platform/fabric/ComponentConversionTest.java
+++ b/src/test/java/net/kyori/adventure/platform/fabric/ComponentConversionTest.java
@@ -134,6 +134,6 @@ class ComponentConversionTest extends BootstrappedTest {
 
   private WrappedComponent toNativeWrapped(final Component component) {
     final Function<Pointered, Locale> partition = AdventureCommon.localePartition();
-    return new WrappedComponent(component, partition, GlobalTranslator.renderer().mapContext(partition));
+    return new WrappedComponent(component, partition, GlobalTranslator.renderer().mapContext(partition), null);
   }
 }


### PR DESCRIPTION
fixes #145 (kind of, consumers need to move from `#asComponent` to deprecated `FabricAudiences#toAdventure` where registry access is required)