### PR TITLE
Add dependencies to fabric-repack

### DIFF
--- a/fabric/mod-shared-repack/build.gradle.kts
+++ b/fabric/mod-shared-repack/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   alias(libs.plugins.loom)
   alias(libs.plugins.indra)
   alias(libs.plugins.indra.publishing)
+  id("standard-conventions")
 }
 
 dependencies {


### PR DESCRIPTION
Fixes transitive dependencies missing when using this module in a consumer 'common module'