### PR TITLE
Implement interface injection on NeoForge

### DIFF
--- a/fabric/src/main/resource-templates/fabric.mod.yaml
+++ b/fabric/src/main/resource-templates/fabric.mod.yaml
@@ -43,7 +43,7 @@ custom:
     net/minecraft/class_2960: [ net/kyori/adventure/key/Key ] # net/minecraft/resources/ResourceLocation
     net/minecraft/class_3414: [ net/kyori/adventure/sound/Sound<%= '$' %>Type ] # net/minecraft/sounds/SoundEvent
     net/minecraft/class_5321: [ net/kyori/adventure/key/Keyed ] # net/minecraft/resources/ResourceKey
-    net/minecraft/class_1799: [ "net/kyori/adventure/text/event/HoverEventSource<Lnet/kyori/adventure/text/event/HoverEvent<%= '$' %>ShowItem;>" ] # net/minecraft/world/item/ItemStack # generic?
+    net/minecraft/class_1799: [ net/kyori/adventure/platform/modcommon/ItemHoverEventSource ] # net/minecraft/world/item/ItemStack # generic?
     net/minecraft/class_7469: [ net/kyori/adventure/chat/SignedMessage<%= '$' %>Signature ] # net/minecraft/network/chat/MessageSignature
 
 depends:

--- a/mod-shared/src/main/java/net/kyori/adventure/platform/modcommon/ItemHoverEventSource.java
+++ b/mod-shared/src/main/java/net/kyori/adventure/platform/modcommon/ItemHoverEventSource.java
@@ -1,0 +1,21 @@
+package net.kyori.adventure.platform.modcommon;
+
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.event.HoverEvent.ShowItem;
+import net.kyori.adventure.text.event.HoverEventSource;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Marker interface for item hover event sources.
+ * Used by interface injection on {@link net.minecraft.world.item.ItemStack}.
+ */
+public interface ItemHoverEventSource extends HoverEventSource<ShowItem> {
+
+  @Override
+  default HoverEvent<ShowItem> asHoverEvent(@NotNull UnaryOperator<ShowItem> op) {
+    throw new UnsupportedOperationException("Method must be overridden by Mixin");
+  }
+  
+}

--- a/mod-shared/src/mixin/java/net/kyori/adventure/platform/modcommon/impl/mixin/minecraft/world/item/ItemStackMixin.java
+++ b/mod-shared/src/mixin/java/net/kyori/adventure/platform/modcommon/impl/mixin/minecraft/world/item/ItemStackMixin.java
@@ -23,16 +23,11 @@
  */
 package net.kyori.adventure.platform.modcommon.impl.mixin.minecraft.world.item;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.UnaryOperator;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.platform.modcommon.ItemHoverEventSource;
 import net.kyori.adventure.platform.modcommon.impl.nbt.ModDataComponentValue;
 import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEventSource;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -42,8 +37,14 @@ import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin implements HoverEventSource<HoverEvent.ShowItem> {
+public abstract class ItemStackMixin implements ItemHoverEventSource {
   // @formatter:off
   @Shadow public abstract int shadow$getCount();
   @Shadow public abstract Item shadow$getItem();

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -26,6 +26,11 @@ neoForge {
       sourceSet(sourceSets.main.get())
     }
   }
+
+  interfaceInjectionData {
+    from(file("interfaces.json"))
+    publish(file("interfaces.json"))
+  }
 }
 
 configurations.jarJar {

--- a/neoforge/interfaces.json
+++ b/neoforge/interfaces.json
@@ -1,0 +1,39 @@
+{
+  "net/minecraft/commands/CommandSourceStack": [
+    "net/kyori/adventure/platform/modcommon/AdventureCommandSourceStack"
+  ],
+  "net/minecraft/world/entity/Entity": [
+    "net/kyori/adventure/sound/Sound$Emitter",
+    "net/kyori/adventure/platform/modcommon/EntityHoverEventSource"
+  ],
+  "net/minecraft/server/MinecraftServer": [
+    "net/kyori/adventure/audience/Audience"
+  ],
+  "net/minecraft/world/entity/player/Player": [
+    "net/kyori/adventure/platform/modcommon/IdentifiedAtRuntime"
+  ],
+  "net/minecraft/server/rcon/RconConsoleSource": [
+    "net/kyori/adventure/audience/Audience"
+  ],
+  "net/minecraft/server/level/ServerPlayer": [
+    "net/kyori/adventure/audience/Audience"
+  ],
+  "net/minecraft/client/player/LocalPlayer": [
+    "net/kyori/adventure/audience/Audience"
+  ],
+  "net/minecraft/resources/ResourceLocation": [
+    "net/kyori/adventure/key/Key"
+  ],
+  "net/minecraft/sounds/SoundEvent": [
+    "net/kyori/adventure/sound/Sound$Type"
+  ],
+  "net/minecraft/resources/ResourceKey": [
+    "net/kyori/adventure/key/Keyed"
+  ],
+  "net/minecraft/world/item/ItemStack": [
+    "net/kyori/adventure/platform/modcommon/ItemHoverEventSource"
+  ],
+  "net/minecraft/network/chat/MessageSignature": [
+    "net/kyori/adventure/chat/SignedMessage$Signature"
+  ]
+}


### PR DESCRIPTION
This was relatively easy to implement as ModDevGradle already supports interface injection, though with a slightly different format to Fabric's.

I also had to add an ItemHoverEventSource interface since custom classes with generic arguments (and on top of that an inner class as generic argument) don't work properly yet (see neoforged/JavaSourceTransformer#53).
Because of that, the mixin and fabric.mod.json were changed to that interface, as well.

This change should be able to be backported to older versions as well, but I don't think there exists a branch for the legacy 1.21 NeoForge codebase...? Either way, not a big deal since it's just explicit vs. implicit casts