### PR TITLE
Fix openBook implementation on Fabric

### DIFF
--- a/mod-shared/src/main/java/net/kyori/adventure/platform/modcommon/impl/server/ServerPlayerAudience.java
+++ b/mod-shared/src/main/java/net/kyori/adventure/platform/modcommon/impl/server/ServerPlayerAudience.java
@@ -70,6 +70,7 @@ import net.minecraft.network.protocol.game.ClientboundBundlePacket;
 import net.minecraft.network.protocol.game.ClientboundClearTitlesPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundDeleteChatPacket;
+import net.minecraft.network.protocol.game.ClientboundOpenBookPacket;
 import net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
@@ -274,9 +275,7 @@ public class ServerPlayerAudience implements ControlledAudience {
     );
 
     final ItemStack previous = this.player.getInventory().getSelectedItem();
-    this.sendPacket(new ClientboundContainerSetSlotPacket(-2, this.player.containerMenu.getStateId(), this.player.getInventory().getSelectedSlot(), bookStack));
-    this.player.openItemGui(bookStack, InteractionHand.MAIN_HAND);
-    this.sendPacket(new ClientboundContainerSetSlotPacket(-2, this.player.containerMenu.getStateId(), this.player.getInventory().getSelectedSlot(), previous));
+    this.sendPacket(new ClientboundBundlePacket(List.of(new ClientboundContainerSetSlotPacket(-2, this.player.containerMenu.getStateId(), this.player.getInventory().getSelectedSlot(), bookStack), new ClientboundOpenBookPacket(InteractionHand.MAIN_HAND), new ClientboundContainerSetSlotPacket(-2, this.player.containerMenu.getStateId(), this.player.getInventory().getSelectedSlot(), previous))));
   }
 
   private static String validateField(final String content, final int length, final String name) {


### PR DESCRIPTION
Currently on Fabric, calling openBook on a ServerPlayer does nothing. The exact same code works just fine on Paper, but fails silently on Fabric. 

This PR fixes that by sending the three necessary packets as a bundle. This is 1-1 exactly how it works in CraftPlayer for the Paper implementation, so it should be a suitable fix here!